### PR TITLE
Don't export function symbols outside the package.

### DIFF
--- a/package.tmpl
+++ b/package.tmpl
@@ -54,7 +54,7 @@ package {{.Name}}
 // {{end}}
 //
 // {{range .Functions}}
-// {{.Return.CType}} glow{{.GoName}}(P{{toUpper .GoName}} fnptr{{if ge (len .Parameters) 1}}, {{end}}{{template "paramsCDecl" .Parameters}}) {
+// static {{.Return.CType}} glow{{.GoName}}(P{{toUpper .GoName}} fnptr{{if ge (len .Parameters) 1}}, {{end}}{{template "paramsCDecl" .Parameters}}) {
 //   {{if not .Return.IsVoid}}return {{end}}(*fnptr)({{template "paramsCCall" .Parameters}});
 // }
 // {{end}}


### PR DESCRIPTION
glowDebugCallback still need to be fixed.
