### PR TITLE
Use uint8 for GLchar and GLcharARB. Fix #47.

### DIFF
--- a/conversions.tmpl
+++ b/conversions.tmpl
@@ -52,12 +52,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-compatibility/3.2/gl/conversions.go
+++ b/gl-compatibility/3.2/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-compatibility/3.2/gl/package.go
+++ b/gl-compatibility/3.2/gl/package.go
@@ -11248,10 +11248,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -18736,7 +18735,7 @@ func ActiveTexture(texture uint32) {
 func ActiveTextureARB(texture uint32) {
 	C.glowActiveTextureARB(gpActiveTextureARB, (C.GLenum)(texture))
 }
-func ActiveVaryingNV(program uint32, name *int8) {
+func ActiveVaryingNV(program uint32, name *uint8) {
 	C.glowActiveVaryingNV(gpActiveVaryingNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func AlphaFragmentOp1ATI(op uint32, dst uint32, dstMod uint32, arg1 uint32, arg1Rep uint32, arg1Mod uint32) {
@@ -18853,10 +18852,10 @@ func BeginVideoCaptureNV(video_capture_slot uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindAttribLocationARB(programObj uintptr, index uint32, name *int8) {
+func BindAttribLocationARB(programObj uintptr, index uint32, name *uint8) {
 	C.glowBindAttribLocationARB(gpBindAttribLocationARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
@@ -18907,15 +18906,15 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindFragDataLocationEXT(program uint32, color uint32, name *int8) {
+func BindFragDataLocationEXT(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocationEXT(gpBindFragDataLocationEXT, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func BindFragmentShaderATI(id uint32) {
@@ -19654,7 +19653,7 @@ func CompileShader(shader uint32) {
 func CompileShaderARB(shaderObj uintptr) {
 	C.glowCompileShaderARB(gpCompileShaderARB, (C.GLhandleARB)(shaderObj))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
@@ -20010,17 +20009,17 @@ func CreateShaderObjectARB(shaderType uint32) uintptr {
 	ret := C.glowCreateShaderObjectARB(gpCreateShaderObjectARB, (C.GLenum)(shaderType))
 	return (uintptr)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -20090,16 +20089,16 @@ func DebugMessageEnableAMD(category uint32, severity uint32, count int32, ids *u
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *int8) {
+func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertAMD(gpDebugMessageInsertAMD, (C.GLenum)(category), (C.GLenum)(severity), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 func DeformSGIX(mask uint32) {
@@ -20144,7 +20143,7 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeleteNamesAMD(identifier uint32, num uint32, names *uint32) {
@@ -21091,20 +21090,20 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttribARB(gpGetActiveAttribARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -21112,15 +21111,15 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniformARB(gpGetActiveUniformARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -21128,7 +21127,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -21136,7 +21135,7 @@ func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, le
 func GetActiveUniformsiv(program uint32, uniformCount int32, uniformIndices *uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformsiv(gpGetActiveUniformsiv, (C.GLuint)(program), (C.GLsizei)(uniformCount), (*C.GLuint)(unsafe.Pointer(uniformIndices)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveVaryingNV(gpGetActiveVaryingNV, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetArrayObjectfvATI(array uint32, pname uint32, params *float32) {
@@ -21155,11 +21154,11 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetAttribLocationARB(programObj uintptr, name *int8) int32 {
+func GetAttribLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetAttribLocationARB(gpGetAttribLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21308,19 +21307,19 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *int8) uint32 {
+func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogAMD(gpGetDebugMessageLogAMD, (C.GLuint)(count), (C.GLsizei)(bufsize), (*C.GLenum)(unsafe.Pointer(categories)), (*C.GLuint)(unsafe.Pointer(severities)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(message)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -21377,17 +21376,17 @@ func GetFogFuncSGIS(points *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetFragDataLocationEXT(program uint32, name *int8) int32 {
+func GetFragDataLocationEXT(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocationEXT(gpGetFragDataLocationEXT, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21474,7 +21473,7 @@ func GetImageTransformParameterfvHP(target uint32, pname uint32, params *float32
 func GetImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowGetImageTransformParameterivHP(gpGetImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *int8) {
+func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *uint8) {
 	C.glowGetInfoLogARB(gpGetInfoLogARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(infoLog)))
 }
 func GetInstrumentsSGIX() int32 {
@@ -21721,10 +21720,10 @@ func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *
 func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -21738,13 +21737,13 @@ func GetObjectBufferivATI(buffer uint32, pname uint32, params *int32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectParameterfvARB(obj uintptr, pname uint32, params *float32) {
@@ -21758,10 +21757,10 @@ func GetObjectParameterivARB(obj uintptr, pname uint32, params *int32) {
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetOcclusionQueryivNV(id uint32, pname uint32, params *int32) {
@@ -21810,7 +21809,7 @@ func GetPathTexGenfvNV(texCoordSet uint32, pname uint32, value *float32) {
 func GetPathTexGenivNV(texCoordSet uint32, pname uint32, value *int32) {
 	C.glowGetPathTexGenivNV(gpGetPathTexGenivNV, (C.GLenum)(texCoordSet), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -21819,13 +21818,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -21834,10 +21833,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapfv(xmap uint32, values *float32) {
@@ -21905,7 +21904,7 @@ func GetProgramEnvParameterfvARB(target uint32, index uint32, params *float32) {
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -21937,10 +21936,10 @@ func GetProgramParameterfvNV(target uint32, index uint32, pname uint32, params *
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -21951,25 +21950,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
@@ -22068,7 +22067,7 @@ func GetSeparableFilterEXT(target uint32, format uint32, xtype uint32, row unsaf
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -22078,10 +22077,10 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
-func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *int8) {
+func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *uint8) {
 	C.glowGetShaderSourceARB(gpGetShaderSourceARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(source)))
 }
 
@@ -22104,13 +22103,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22257,10 +22256,10 @@ func GetTrackMatrixivNV(target uint32, address uint32, pname uint32, params *int
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVaryingEXT(gpGetTransformFeedbackVaryingEXT, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbackVaryingNV(program uint32, index uint32, location *int32) {
@@ -22279,7 +22278,7 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
@@ -22289,16 +22288,16 @@ func GetUniformBufferSizeEXT(program uint32, location int32) int32 {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetUniformLocationARB(programObj uintptr, name *int8) int32 {
+func GetUniformLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetUniformLocationARB(gpGetUniformLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22358,7 +22357,7 @@ func GetVariantIntegervEXT(id uint32, value uint32, data *int32) {
 func GetVariantPointervEXT(id uint32, value uint32, data *unsafe.Pointer) {
 	C.glowGetVariantPointervEXT(gpGetVariantPointervEXT, (C.GLuint)(id), (C.GLenum)(value), data)
 }
-func GetVaryingLocationNV(program uint32, name *int8) int32 {
+func GetVaryingLocationNV(program uint32, name *uint8) int32 {
 	ret := C.glowGetVaryingLocationNV(gpGetVaryingLocationNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22692,7 +22691,7 @@ func InitNames() {
 func InsertComponentEXT(res uint32, src uint32, num uint32) {
 	C.glowInsertComponentEXT(gpInsertComponentEXT, (C.GLuint)(res), (C.GLuint)(src), (C.GLuint)(num))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 func InstrumentsBufferSGIX(size int32, buffer *int32) {
@@ -22816,7 +22815,7 @@ func IsNamedBufferResidentNV(buffer uint32) bool {
 	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -22948,7 +22947,7 @@ func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightEnviSGIX(pname uint32, param int32) {
@@ -23944,7 +23943,7 @@ func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverag
 func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 
@@ -24059,18 +24058,18 @@ func NormalStream3svATI(stream uint32, coords *int16) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func ObjectPurgeableAPPLE(objectType uint32, name uint32, option uint32) uint32 {
@@ -24977,13 +24976,13 @@ func PushClientAttribDefaultEXT(mask uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -25550,10 +25549,10 @@ func ShaderOp3EXT(op uint32, res uint32, arg1 uint32, arg2 uint32, arg3 uint32) 
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
-func ShaderSourceARB(shaderObj uintptr, count int32, xstring **int8, length *int32) {
+func ShaderSourceARB(shaderObj uintptr, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSourceARB(gpShaderSourceARB, (C.GLhandleARB)(shaderObj), (C.GLsizei)(count), (**C.GLcharARB)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -26355,10 +26354,10 @@ func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int3
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
-func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryingsEXT(gpTransformFeedbackVaryingsEXT, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TransformFeedbackVaryingsNV(program uint32, count int32, locations *int32, bufferMode uint32) {

--- a/gl-compatibility/3.3/gl/conversions.go
+++ b/gl-compatibility/3.3/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-compatibility/3.3/gl/package.go
+++ b/gl-compatibility/3.3/gl/package.go
@@ -11252,10 +11252,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -18742,7 +18741,7 @@ func ActiveTexture(texture uint32) {
 func ActiveTextureARB(texture uint32) {
 	C.glowActiveTextureARB(gpActiveTextureARB, (C.GLenum)(texture))
 }
-func ActiveVaryingNV(program uint32, name *int8) {
+func ActiveVaryingNV(program uint32, name *uint8) {
 	C.glowActiveVaryingNV(gpActiveVaryingNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func AlphaFragmentOp1ATI(op uint32, dst uint32, dstMod uint32, arg1 uint32, arg1Rep uint32, arg1Mod uint32) {
@@ -18859,10 +18858,10 @@ func BeginVideoCaptureNV(video_capture_slot uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindAttribLocationARB(programObj uintptr, index uint32, name *int8) {
+func BindAttribLocationARB(programObj uintptr, index uint32, name *uint8) {
 	C.glowBindAttribLocationARB(gpBindAttribLocationARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
@@ -18913,15 +18912,15 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindFragDataLocationEXT(program uint32, color uint32, name *int8) {
+func BindFragDataLocationEXT(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocationEXT(gpBindFragDataLocationEXT, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func BindFragmentShaderATI(id uint32) {
@@ -19660,7 +19659,7 @@ func CompileShader(shader uint32) {
 func CompileShaderARB(shaderObj uintptr) {
 	C.glowCompileShaderARB(gpCompileShaderARB, (C.GLhandleARB)(shaderObj))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
@@ -20016,17 +20015,17 @@ func CreateShaderObjectARB(shaderType uint32) uintptr {
 	ret := C.glowCreateShaderObjectARB(gpCreateShaderObjectARB, (C.GLenum)(shaderType))
 	return (uintptr)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -20096,16 +20095,16 @@ func DebugMessageEnableAMD(category uint32, severity uint32, count int32, ids *u
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *int8) {
+func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertAMD(gpDebugMessageInsertAMD, (C.GLenum)(category), (C.GLenum)(severity), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 func DeformSGIX(mask uint32) {
@@ -20150,7 +20149,7 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeleteNamesAMD(identifier uint32, num uint32, names *uint32) {
@@ -21097,20 +21096,20 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttribARB(gpGetActiveAttribARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -21118,15 +21117,15 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniformARB(gpGetActiveUniformARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -21134,7 +21133,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -21142,7 +21141,7 @@ func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, le
 func GetActiveUniformsiv(program uint32, uniformCount int32, uniformIndices *uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformsiv(gpGetActiveUniformsiv, (C.GLuint)(program), (C.GLsizei)(uniformCount), (*C.GLuint)(unsafe.Pointer(uniformIndices)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveVaryingNV(gpGetActiveVaryingNV, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetArrayObjectfvATI(array uint32, pname uint32, params *float32) {
@@ -21161,11 +21160,11 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetAttribLocationARB(programObj uintptr, name *int8) int32 {
+func GetAttribLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetAttribLocationARB(gpGetAttribLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21314,19 +21313,19 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *int8) uint32 {
+func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogAMD(gpGetDebugMessageLogAMD, (C.GLuint)(count), (C.GLsizei)(bufsize), (*C.GLenum)(unsafe.Pointer(categories)), (*C.GLuint)(unsafe.Pointer(severities)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(message)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -21383,17 +21382,17 @@ func GetFogFuncSGIS(points *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetFragDataLocationEXT(program uint32, name *int8) int32 {
+func GetFragDataLocationEXT(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocationEXT(gpGetFragDataLocationEXT, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21480,7 +21479,7 @@ func GetImageTransformParameterfvHP(target uint32, pname uint32, params *float32
 func GetImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowGetImageTransformParameterivHP(gpGetImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *int8) {
+func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *uint8) {
 	C.glowGetInfoLogARB(gpGetInfoLogARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(infoLog)))
 }
 func GetInstrumentsSGIX() int32 {
@@ -21727,10 +21726,10 @@ func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *
 func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -21744,13 +21743,13 @@ func GetObjectBufferivATI(buffer uint32, pname uint32, params *int32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectParameterfvARB(obj uintptr, pname uint32, params *float32) {
@@ -21764,10 +21763,10 @@ func GetObjectParameterivARB(obj uintptr, pname uint32, params *int32) {
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetOcclusionQueryivNV(id uint32, pname uint32, params *int32) {
@@ -21816,7 +21815,7 @@ func GetPathTexGenfvNV(texCoordSet uint32, pname uint32, value *float32) {
 func GetPathTexGenivNV(texCoordSet uint32, pname uint32, value *int32) {
 	C.glowGetPathTexGenivNV(gpGetPathTexGenivNV, (C.GLenum)(texCoordSet), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -21825,13 +21824,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -21840,10 +21839,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapfv(xmap uint32, values *float32) {
@@ -21911,7 +21910,7 @@ func GetProgramEnvParameterfvARB(target uint32, index uint32, params *float32) {
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -21943,10 +21942,10 @@ func GetProgramParameterfvNV(target uint32, index uint32, pname uint32, params *
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -21957,25 +21956,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
@@ -22074,7 +22073,7 @@ func GetSeparableFilterEXT(target uint32, format uint32, xtype uint32, row unsaf
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -22084,10 +22083,10 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
-func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *int8) {
+func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *uint8) {
 	C.glowGetShaderSourceARB(gpGetShaderSourceARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(source)))
 }
 
@@ -22110,13 +22109,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22263,10 +22262,10 @@ func GetTrackMatrixivNV(target uint32, address uint32, pname uint32, params *int
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVaryingEXT(gpGetTransformFeedbackVaryingEXT, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbackVaryingNV(program uint32, index uint32, location *int32) {
@@ -22285,7 +22284,7 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
@@ -22295,16 +22294,16 @@ func GetUniformBufferSizeEXT(program uint32, location int32) int32 {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetUniformLocationARB(programObj uintptr, name *int8) int32 {
+func GetUniformLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetUniformLocationARB(gpGetUniformLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22364,7 +22363,7 @@ func GetVariantIntegervEXT(id uint32, value uint32, data *int32) {
 func GetVariantPointervEXT(id uint32, value uint32, data *unsafe.Pointer) {
 	C.glowGetVariantPointervEXT(gpGetVariantPointervEXT, (C.GLuint)(id), (C.GLenum)(value), data)
 }
-func GetVaryingLocationNV(program uint32, name *int8) int32 {
+func GetVaryingLocationNV(program uint32, name *uint8) int32 {
 	ret := C.glowGetVaryingLocationNV(gpGetVaryingLocationNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22698,7 +22697,7 @@ func InitNames() {
 func InsertComponentEXT(res uint32, src uint32, num uint32) {
 	C.glowInsertComponentEXT(gpInsertComponentEXT, (C.GLuint)(res), (C.GLuint)(src), (C.GLuint)(num))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 func InstrumentsBufferSGIX(size int32, buffer *int32) {
@@ -22822,7 +22821,7 @@ func IsNamedBufferResidentNV(buffer uint32) bool {
 	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -22954,7 +22953,7 @@ func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightEnviSGIX(pname uint32, param int32) {
@@ -23950,7 +23949,7 @@ func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverag
 func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 
@@ -24065,18 +24064,18 @@ func NormalStream3svATI(stream uint32, coords *int16) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func ObjectPurgeableAPPLE(objectType uint32, name uint32, option uint32) uint32 {
@@ -24983,13 +24982,13 @@ func PushClientAttribDefaultEXT(mask uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -25556,10 +25555,10 @@ func ShaderOp3EXT(op uint32, res uint32, arg1 uint32, arg2 uint32, arg3 uint32) 
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
-func ShaderSourceARB(shaderObj uintptr, count int32, xstring **int8, length *int32) {
+func ShaderSourceARB(shaderObj uintptr, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSourceARB(gpShaderSourceARB, (C.GLhandleARB)(shaderObj), (C.GLsizei)(count), (**C.GLcharARB)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -26361,10 +26360,10 @@ func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int3
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
-func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryingsEXT(gpTransformFeedbackVaryingsEXT, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TransformFeedbackVaryingsNV(program uint32, count int32, locations *int32, bufferMode uint32) {

--- a/gl-compatibility/4.1/gl/conversions.go
+++ b/gl-compatibility/4.1/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-compatibility/4.1/gl/package.go
+++ b/gl-compatibility/4.1/gl/package.go
@@ -11272,10 +11272,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -18776,7 +18775,7 @@ func ActiveTexture(texture uint32) {
 func ActiveTextureARB(texture uint32) {
 	C.glowActiveTextureARB(gpActiveTextureARB, (C.GLenum)(texture))
 }
-func ActiveVaryingNV(program uint32, name *int8) {
+func ActiveVaryingNV(program uint32, name *uint8) {
 	C.glowActiveVaryingNV(gpActiveVaryingNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func AlphaFragmentOp1ATI(op uint32, dst uint32, dstMod uint32, arg1 uint32, arg1Rep uint32, arg1Mod uint32) {
@@ -18893,10 +18892,10 @@ func BeginVideoCaptureNV(video_capture_slot uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindAttribLocationARB(programObj uintptr, index uint32, name *int8) {
+func BindAttribLocationARB(programObj uintptr, index uint32, name *uint8) {
 	C.glowBindAttribLocationARB(gpBindAttribLocationARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
@@ -18947,15 +18946,15 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindFragDataLocationEXT(program uint32, color uint32, name *int8) {
+func BindFragDataLocationEXT(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocationEXT(gpBindFragDataLocationEXT, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func BindFragmentShaderATI(id uint32) {
@@ -19706,7 +19705,7 @@ func CompileShader(shader uint32) {
 func CompileShaderARB(shaderObj uintptr) {
 	C.glowCompileShaderARB(gpCompileShaderARB, (C.GLhandleARB)(shaderObj))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
@@ -20062,17 +20061,17 @@ func CreateShaderObjectARB(shaderType uint32) uintptr {
 	ret := C.glowCreateShaderObjectARB(gpCreateShaderObjectARB, (C.GLenum)(shaderType))
 	return (uintptr)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -20142,16 +20141,16 @@ func DebugMessageEnableAMD(category uint32, severity uint32, count int32, ids *u
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *int8) {
+func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertAMD(gpDebugMessageInsertAMD, (C.GLenum)(category), (C.GLenum)(severity), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 func DeformSGIX(mask uint32) {
@@ -20196,7 +20195,7 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeleteNamesAMD(identifier uint32, num uint32, names *uint32) {
@@ -21143,20 +21142,20 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttribARB(gpGetActiveAttribARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -21164,15 +21163,15 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniformARB(gpGetActiveUniformARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -21180,7 +21179,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -21188,7 +21187,7 @@ func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, le
 func GetActiveUniformsiv(program uint32, uniformCount int32, uniformIndices *uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformsiv(gpGetActiveUniformsiv, (C.GLuint)(program), (C.GLsizei)(uniformCount), (*C.GLuint)(unsafe.Pointer(uniformIndices)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveVaryingNV(gpGetActiveVaryingNV, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetArrayObjectfvATI(array uint32, pname uint32, params *float32) {
@@ -21207,11 +21206,11 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetAttribLocationARB(programObj uintptr, name *int8) int32 {
+func GetAttribLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetAttribLocationARB(gpGetAttribLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21360,19 +21359,19 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *int8) uint32 {
+func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogAMD(gpGetDebugMessageLogAMD, (C.GLuint)(count), (C.GLsizei)(bufsize), (*C.GLenum)(unsafe.Pointer(categories)), (*C.GLuint)(unsafe.Pointer(severities)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(message)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -21429,17 +21428,17 @@ func GetFogFuncSGIS(points *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetFragDataLocationEXT(program uint32, name *int8) int32 {
+func GetFragDataLocationEXT(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocationEXT(gpGetFragDataLocationEXT, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21526,7 +21525,7 @@ func GetImageTransformParameterfvHP(target uint32, pname uint32, params *float32
 func GetImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowGetImageTransformParameterivHP(gpGetImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *int8) {
+func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *uint8) {
 	C.glowGetInfoLogARB(gpGetInfoLogARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(infoLog)))
 }
 func GetInstrumentsSGIX() int32 {
@@ -21773,10 +21772,10 @@ func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *
 func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -21790,13 +21789,13 @@ func GetObjectBufferivATI(buffer uint32, pname uint32, params *int32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectParameterfvARB(obj uintptr, pname uint32, params *float32) {
@@ -21810,10 +21809,10 @@ func GetObjectParameterivARB(obj uintptr, pname uint32, params *int32) {
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetOcclusionQueryivNV(id uint32, pname uint32, params *int32) {
@@ -21862,7 +21861,7 @@ func GetPathTexGenfvNV(texCoordSet uint32, pname uint32, value *float32) {
 func GetPathTexGenivNV(texCoordSet uint32, pname uint32, value *int32) {
 	C.glowGetPathTexGenivNV(gpGetPathTexGenivNV, (C.GLenum)(texCoordSet), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -21871,13 +21870,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -21886,10 +21885,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapfv(xmap uint32, values *float32) {
@@ -21957,7 +21956,7 @@ func GetProgramEnvParameterfvARB(target uint32, index uint32, params *float32) {
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -21989,10 +21988,10 @@ func GetProgramParameterfvNV(target uint32, index uint32, pname uint32, params *
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -22003,25 +22002,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
@@ -22120,7 +22119,7 @@ func GetSeparableFilterEXT(target uint32, format uint32, xtype uint32, row unsaf
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -22130,10 +22129,10 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
-func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *int8) {
+func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *uint8) {
 	C.glowGetShaderSourceARB(gpGetShaderSourceARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(source)))
 }
 
@@ -22156,13 +22155,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22309,10 +22308,10 @@ func GetTrackMatrixivNV(target uint32, address uint32, pname uint32, params *int
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVaryingEXT(gpGetTransformFeedbackVaryingEXT, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbackVaryingNV(program uint32, index uint32, location *int32) {
@@ -22331,7 +22330,7 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
@@ -22341,16 +22340,16 @@ func GetUniformBufferSizeEXT(program uint32, location int32) int32 {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetUniformLocationARB(programObj uintptr, name *int8) int32 {
+func GetUniformLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetUniformLocationARB(gpGetUniformLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22410,7 +22409,7 @@ func GetVariantIntegervEXT(id uint32, value uint32, data *int32) {
 func GetVariantPointervEXT(id uint32, value uint32, data *unsafe.Pointer) {
 	C.glowGetVariantPointervEXT(gpGetVariantPointervEXT, (C.GLuint)(id), (C.GLenum)(value), data)
 }
-func GetVaryingLocationNV(program uint32, name *int8) int32 {
+func GetVaryingLocationNV(program uint32, name *uint8) int32 {
 	ret := C.glowGetVaryingLocationNV(gpGetVaryingLocationNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22744,7 +22743,7 @@ func InitNames() {
 func InsertComponentEXT(res uint32, src uint32, num uint32) {
 	C.glowInsertComponentEXT(gpInsertComponentEXT, (C.GLuint)(res), (C.GLuint)(src), (C.GLuint)(num))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 func InstrumentsBufferSGIX(size int32, buffer *int32) {
@@ -22868,7 +22867,7 @@ func IsNamedBufferResidentNV(buffer uint32) bool {
 	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -23000,7 +22999,7 @@ func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightEnviSGIX(pname uint32, param int32) {
@@ -24001,7 +24000,7 @@ func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverag
 func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 
@@ -24116,18 +24115,18 @@ func NormalStream3svATI(stream uint32, coords *int16) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func ObjectPurgeableAPPLE(objectType uint32, name uint32, option uint32) uint32 {
@@ -25034,13 +25033,13 @@ func PushClientAttribDefaultEXT(mask uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -25607,10 +25606,10 @@ func ShaderOp3EXT(op uint32, res uint32, arg1 uint32, arg2 uint32, arg3 uint32) 
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
-func ShaderSourceARB(shaderObj uintptr, count int32, xstring **int8, length *int32) {
+func ShaderSourceARB(shaderObj uintptr, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSourceARB(gpShaderSourceARB, (C.GLhandleARB)(shaderObj), (C.GLsizei)(count), (**C.GLcharARB)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -26412,10 +26411,10 @@ func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int3
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
-func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryingsEXT(gpTransformFeedbackVaryingsEXT, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TransformFeedbackVaryingsNV(program uint32, count int32, locations *int32, bufferMode uint32) {

--- a/gl-compatibility/4.4/gl/conversions.go
+++ b/gl-compatibility/4.4/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-compatibility/4.4/gl/package.go
+++ b/gl-compatibility/4.4/gl/package.go
@@ -11272,10 +11272,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -18786,7 +18785,7 @@ func ActiveTexture(texture uint32) {
 func ActiveTextureARB(texture uint32) {
 	C.glowActiveTextureARB(gpActiveTextureARB, (C.GLenum)(texture))
 }
-func ActiveVaryingNV(program uint32, name *int8) {
+func ActiveVaryingNV(program uint32, name *uint8) {
 	C.glowActiveVaryingNV(gpActiveVaryingNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func AlphaFragmentOp1ATI(op uint32, dst uint32, dstMod uint32, arg1 uint32, arg1Rep uint32, arg1Mod uint32) {
@@ -18903,10 +18902,10 @@ func BeginVideoCaptureNV(video_capture_slot uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindAttribLocationARB(programObj uintptr, index uint32, name *int8) {
+func BindAttribLocationARB(programObj uintptr, index uint32, name *uint8) {
 	C.glowBindAttribLocationARB(gpBindAttribLocationARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
@@ -18957,15 +18956,15 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindFragDataLocationEXT(program uint32, color uint32, name *int8) {
+func BindFragDataLocationEXT(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocationEXT(gpBindFragDataLocationEXT, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func BindFragmentShaderATI(id uint32) {
@@ -19716,7 +19715,7 @@ func CompileShader(shader uint32) {
 func CompileShaderARB(shaderObj uintptr) {
 	C.glowCompileShaderARB(gpCompileShaderARB, (C.GLhandleARB)(shaderObj))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
@@ -20072,17 +20071,17 @@ func CreateShaderObjectARB(shaderType uint32) uintptr {
 	ret := C.glowCreateShaderObjectARB(gpCreateShaderObjectARB, (C.GLenum)(shaderType))
 	return (uintptr)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -20152,16 +20151,16 @@ func DebugMessageEnableAMD(category uint32, severity uint32, count int32, ids *u
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *int8) {
+func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertAMD(gpDebugMessageInsertAMD, (C.GLenum)(category), (C.GLenum)(severity), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 func DeformSGIX(mask uint32) {
@@ -20206,7 +20205,7 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeleteNamesAMD(identifier uint32, num uint32, names *uint32) {
@@ -21153,20 +21152,20 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttribARB(gpGetActiveAttribARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -21174,15 +21173,15 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniformARB(gpGetActiveUniformARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -21190,7 +21189,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -21198,7 +21197,7 @@ func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, le
 func GetActiveUniformsiv(program uint32, uniformCount int32, uniformIndices *uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformsiv(gpGetActiveUniformsiv, (C.GLuint)(program), (C.GLsizei)(uniformCount), (*C.GLuint)(unsafe.Pointer(uniformIndices)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveVaryingNV(gpGetActiveVaryingNV, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetArrayObjectfvATI(array uint32, pname uint32, params *float32) {
@@ -21217,11 +21216,11 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetAttribLocationARB(programObj uintptr, name *int8) int32 {
+func GetAttribLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetAttribLocationARB(gpGetAttribLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21370,19 +21369,19 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *int8) uint32 {
+func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogAMD(gpGetDebugMessageLogAMD, (C.GLuint)(count), (C.GLsizei)(bufsize), (*C.GLenum)(unsafe.Pointer(categories)), (*C.GLuint)(unsafe.Pointer(severities)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(message)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -21439,17 +21438,17 @@ func GetFogFuncSGIS(points *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetFragDataLocationEXT(program uint32, name *int8) int32 {
+func GetFragDataLocationEXT(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocationEXT(gpGetFragDataLocationEXT, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21536,7 +21535,7 @@ func GetImageTransformParameterfvHP(target uint32, pname uint32, params *float32
 func GetImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowGetImageTransformParameterivHP(gpGetImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *int8) {
+func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *uint8) {
 	C.glowGetInfoLogARB(gpGetInfoLogARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(infoLog)))
 }
 func GetInstrumentsSGIX() int32 {
@@ -21783,10 +21782,10 @@ func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *
 func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -21800,13 +21799,13 @@ func GetObjectBufferivATI(buffer uint32, pname uint32, params *int32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectParameterfvARB(obj uintptr, pname uint32, params *float32) {
@@ -21820,10 +21819,10 @@ func GetObjectParameterivARB(obj uintptr, pname uint32, params *int32) {
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetOcclusionQueryivNV(id uint32, pname uint32, params *int32) {
@@ -21872,7 +21871,7 @@ func GetPathTexGenfvNV(texCoordSet uint32, pname uint32, value *float32) {
 func GetPathTexGenivNV(texCoordSet uint32, pname uint32, value *int32) {
 	C.glowGetPathTexGenivNV(gpGetPathTexGenivNV, (C.GLenum)(texCoordSet), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -21881,13 +21880,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -21896,10 +21895,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapfv(xmap uint32, values *float32) {
@@ -21967,7 +21966,7 @@ func GetProgramEnvParameterfvARB(target uint32, index uint32, params *float32) {
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -21999,10 +21998,10 @@ func GetProgramParameterfvNV(target uint32, index uint32, pname uint32, params *
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -22013,25 +22012,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
@@ -22130,7 +22129,7 @@ func GetSeparableFilterEXT(target uint32, format uint32, xtype uint32, row unsaf
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -22140,10 +22139,10 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
-func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *int8) {
+func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *uint8) {
 	C.glowGetShaderSourceARB(gpGetShaderSourceARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(source)))
 }
 
@@ -22166,13 +22165,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22319,10 +22318,10 @@ func GetTrackMatrixivNV(target uint32, address uint32, pname uint32, params *int
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVaryingEXT(gpGetTransformFeedbackVaryingEXT, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbackVaryingNV(program uint32, index uint32, location *int32) {
@@ -22341,7 +22340,7 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
@@ -22351,16 +22350,16 @@ func GetUniformBufferSizeEXT(program uint32, location int32) int32 {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetUniformLocationARB(programObj uintptr, name *int8) int32 {
+func GetUniformLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetUniformLocationARB(gpGetUniformLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22420,7 +22419,7 @@ func GetVariantIntegervEXT(id uint32, value uint32, data *int32) {
 func GetVariantPointervEXT(id uint32, value uint32, data *unsafe.Pointer) {
 	C.glowGetVariantPointervEXT(gpGetVariantPointervEXT, (C.GLuint)(id), (C.GLenum)(value), data)
 }
-func GetVaryingLocationNV(program uint32, name *int8) int32 {
+func GetVaryingLocationNV(program uint32, name *uint8) int32 {
 	ret := C.glowGetVaryingLocationNV(gpGetVaryingLocationNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22754,7 +22753,7 @@ func InitNames() {
 func InsertComponentEXT(res uint32, src uint32, num uint32) {
 	C.glowInsertComponentEXT(gpInsertComponentEXT, (C.GLuint)(res), (C.GLuint)(src), (C.GLuint)(num))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 func InstrumentsBufferSGIX(size int32, buffer *int32) {
@@ -22878,7 +22877,7 @@ func IsNamedBufferResidentNV(buffer uint32) bool {
 	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -23010,7 +23009,7 @@ func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightEnviSGIX(pname uint32, param int32) {
@@ -24011,7 +24010,7 @@ func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverag
 func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 
@@ -24126,18 +24125,18 @@ func NormalStream3svATI(stream uint32, coords *int16) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func ObjectPurgeableAPPLE(objectType uint32, name uint32, option uint32) uint32 {
@@ -25044,13 +25043,13 @@ func PushClientAttribDefaultEXT(mask uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -25617,10 +25616,10 @@ func ShaderOp3EXT(op uint32, res uint32, arg1 uint32, arg2 uint32, arg3 uint32) 
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
-func ShaderSourceARB(shaderObj uintptr, count int32, xstring **int8, length *int32) {
+func ShaderSourceARB(shaderObj uintptr, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSourceARB(gpShaderSourceARB, (C.GLhandleARB)(shaderObj), (C.GLsizei)(count), (**C.GLcharARB)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -26422,10 +26421,10 @@ func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int3
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
-func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryingsEXT(gpTransformFeedbackVaryingsEXT, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TransformFeedbackVaryingsNV(program uint32, count int32, locations *int32, bufferMode uint32) {

--- a/gl-compatibility/4.5/gl/conversions.go
+++ b/gl-compatibility/4.5/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-compatibility/4.5/gl/package.go
+++ b/gl-compatibility/4.5/gl/package.go
@@ -11332,10 +11332,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -18862,7 +18861,7 @@ func ActiveTexture(texture uint32) {
 func ActiveTextureARB(texture uint32) {
 	C.glowActiveTextureARB(gpActiveTextureARB, (C.GLenum)(texture))
 }
-func ActiveVaryingNV(program uint32, name *int8) {
+func ActiveVaryingNV(program uint32, name *uint8) {
 	C.glowActiveVaryingNV(gpActiveVaryingNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func AlphaFragmentOp1ATI(op uint32, dst uint32, dstMod uint32, arg1 uint32, arg1Rep uint32, arg1Mod uint32) {
@@ -18979,10 +18978,10 @@ func BeginVideoCaptureNV(video_capture_slot uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindAttribLocationARB(programObj uintptr, index uint32, name *int8) {
+func BindAttribLocationARB(programObj uintptr, index uint32, name *uint8) {
 	C.glowBindAttribLocationARB(gpBindAttribLocationARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
@@ -19033,15 +19032,15 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindFragDataLocationEXT(program uint32, color uint32, name *int8) {
+func BindFragDataLocationEXT(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocationEXT(gpBindFragDataLocationEXT, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func BindFragmentShaderATI(id uint32) {
@@ -19792,7 +19791,7 @@ func CompileShader(shader uint32) {
 func CompileShaderARB(shaderObj uintptr) {
 	C.glowCompileShaderARB(gpCompileShaderARB, (C.GLhandleARB)(shaderObj))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
@@ -20148,17 +20147,17 @@ func CreateShaderObjectARB(shaderType uint32) uintptr {
 	ret := C.glowCreateShaderObjectARB(gpCreateShaderObjectARB, (C.GLenum)(shaderType))
 	return (uintptr)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -20228,16 +20227,16 @@ func DebugMessageEnableAMD(category uint32, severity uint32, count int32, ids *u
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *int8) {
+func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertAMD(gpDebugMessageInsertAMD, (C.GLenum)(category), (C.GLenum)(severity), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 func DeformSGIX(mask uint32) {
@@ -20282,7 +20281,7 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeleteNamesAMD(identifier uint32, num uint32, names *uint32) {
@@ -21229,20 +21228,20 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttribARB(gpGetActiveAttribARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -21250,15 +21249,15 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniformARB(gpGetActiveUniformARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -21266,7 +21265,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -21274,7 +21273,7 @@ func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, le
 func GetActiveUniformsiv(program uint32, uniformCount int32, uniformIndices *uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformsiv(gpGetActiveUniformsiv, (C.GLuint)(program), (C.GLsizei)(uniformCount), (*C.GLuint)(unsafe.Pointer(uniformIndices)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveVaryingNV(gpGetActiveVaryingNV, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetArrayObjectfvATI(array uint32, pname uint32, params *float32) {
@@ -21293,11 +21292,11 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetAttribLocationARB(programObj uintptr, name *int8) int32 {
+func GetAttribLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetAttribLocationARB(gpGetAttribLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21446,19 +21445,19 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *int8) uint32 {
+func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogAMD(gpGetDebugMessageLogAMD, (C.GLuint)(count), (C.GLsizei)(bufsize), (*C.GLenum)(unsafe.Pointer(categories)), (*C.GLuint)(unsafe.Pointer(severities)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(message)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -21515,17 +21514,17 @@ func GetFogFuncSGIS(points *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetFragDataLocationEXT(program uint32, name *int8) int32 {
+func GetFragDataLocationEXT(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocationEXT(gpGetFragDataLocationEXT, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21612,7 +21611,7 @@ func GetImageTransformParameterfvHP(target uint32, pname uint32, params *float32
 func GetImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowGetImageTransformParameterivHP(gpGetImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *int8) {
+func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *uint8) {
 	C.glowGetInfoLogARB(gpGetInfoLogARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(infoLog)))
 }
 func GetInstrumentsSGIX() int32 {
@@ -21859,10 +21858,10 @@ func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *
 func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -21876,13 +21875,13 @@ func GetObjectBufferivATI(buffer uint32, pname uint32, params *int32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectParameterfvARB(obj uintptr, pname uint32, params *float32) {
@@ -21896,10 +21895,10 @@ func GetObjectParameterivARB(obj uintptr, pname uint32, params *int32) {
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetOcclusionQueryivNV(id uint32, pname uint32, params *int32) {
@@ -21948,7 +21947,7 @@ func GetPathTexGenfvNV(texCoordSet uint32, pname uint32, value *float32) {
 func GetPathTexGenivNV(texCoordSet uint32, pname uint32, value *int32) {
 	C.glowGetPathTexGenivNV(gpGetPathTexGenivNV, (C.GLenum)(texCoordSet), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -21957,13 +21956,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -21972,10 +21971,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapfv(xmap uint32, values *float32) {
@@ -22043,7 +22042,7 @@ func GetProgramEnvParameterfvARB(target uint32, index uint32, params *float32) {
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -22075,10 +22074,10 @@ func GetProgramParameterfvNV(target uint32, index uint32, pname uint32, params *
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -22089,25 +22088,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
@@ -22206,7 +22205,7 @@ func GetSeparableFilterEXT(target uint32, format uint32, xtype uint32, row unsaf
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -22216,10 +22215,10 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
-func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *int8) {
+func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *uint8) {
 	C.glowGetShaderSourceARB(gpGetShaderSourceARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(source)))
 }
 
@@ -22242,13 +22241,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22395,10 +22394,10 @@ func GetTrackMatrixivNV(target uint32, address uint32, pname uint32, params *int
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVaryingEXT(gpGetTransformFeedbackVaryingEXT, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbackVaryingNV(program uint32, index uint32, location *int32) {
@@ -22417,7 +22416,7 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
@@ -22427,16 +22426,16 @@ func GetUniformBufferSizeEXT(program uint32, location int32) int32 {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetUniformLocationARB(programObj uintptr, name *int8) int32 {
+func GetUniformLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetUniformLocationARB(gpGetUniformLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22496,7 +22495,7 @@ func GetVariantIntegervEXT(id uint32, value uint32, data *int32) {
 func GetVariantPointervEXT(id uint32, value uint32, data *unsafe.Pointer) {
 	C.glowGetVariantPointervEXT(gpGetVariantPointervEXT, (C.GLuint)(id), (C.GLenum)(value), data)
 }
-func GetVaryingLocationNV(program uint32, name *int8) int32 {
+func GetVaryingLocationNV(program uint32, name *uint8) int32 {
 	ret := C.glowGetVaryingLocationNV(gpGetVaryingLocationNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -22879,7 +22878,7 @@ func InitNames() {
 func InsertComponentEXT(res uint32, src uint32, num uint32) {
 	C.glowInsertComponentEXT(gpInsertComponentEXT, (C.GLuint)(res), (C.GLuint)(src), (C.GLuint)(num))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 func InstrumentsBufferSGIX(size int32, buffer *int32) {
@@ -23003,7 +23002,7 @@ func IsNamedBufferResidentNV(buffer uint32) bool {
 	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -23135,7 +23134,7 @@ func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightEnviSGIX(pname uint32, param int32) {
@@ -24136,7 +24135,7 @@ func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverag
 func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 
@@ -24251,18 +24250,18 @@ func NormalStream3svATI(stream uint32, coords *int16) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func ObjectPurgeableAPPLE(objectType uint32, name uint32, option uint32) uint32 {
@@ -25169,13 +25168,13 @@ func PushClientAttribDefaultEXT(mask uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -25742,10 +25741,10 @@ func ShaderOp3EXT(op uint32, res uint32, arg1 uint32, arg2 uint32, arg3 uint32) 
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
-func ShaderSourceARB(shaderObj uintptr, count int32, xstring **int8, length *int32) {
+func ShaderSourceARB(shaderObj uintptr, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSourceARB(gpShaderSourceARB, (C.GLhandleARB)(shaderObj), (C.GLsizei)(count), (**C.GLcharARB)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -26547,10 +26546,10 @@ func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int3
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
-func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryingsEXT(gpTransformFeedbackVaryingsEXT, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TransformFeedbackVaryingsNV(program uint32, count int32, locations *int32, bufferMode uint32) {

--- a/gl-core/3.2/gl/conversions.go
+++ b/gl-core/3.2/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-core/3.2/gl/package.go
+++ b/gl-core/3.2/gl/package.go
@@ -3819,10 +3819,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -6430,7 +6429,7 @@ func BeginTransformFeedback(primitiveMode uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -6460,12 +6459,12 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -6770,7 +6769,7 @@ func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 func CompileShader(shader uint32) {
 	C.glowCompileShader(gpCompileShader, (C.GLuint)(shader))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -6924,17 +6923,17 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -6989,13 +6988,13 @@ func DebugMessageControlKHR(source uint32, xtype uint32, severity uint32, count 
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 
@@ -7011,7 +7010,7 @@ func DeleteFencesNV(n int32, fences *uint32) {
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
 	C.glowDeleteFramebuffers(gpDeleteFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
@@ -7437,17 +7436,17 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -7455,12 +7454,12 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -7468,7 +7467,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -7483,7 +7482,7 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7539,15 +7538,15 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -7580,13 +7579,13 @@ func GetFloatv(pname uint32, data *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7694,10 +7693,10 @@ func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -7705,24 +7704,24 @@ func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -7731,13 +7730,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -7746,10 +7745,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapxv(xmap uint32, size int32, values *int32) {
@@ -7770,7 +7769,7 @@ func GetProgramBinary(program uint32, bufSize int32, length *int32, binaryFormat
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -7778,10 +7777,10 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -7792,25 +7791,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
@@ -7865,7 +7864,7 @@ func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -7875,7 +7874,7 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
 
@@ -7895,13 +7894,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7983,7 +7982,7 @@ func GetTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int3
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbacki64_v(xfb uint32, pname uint32, index uint32, param *int64) {
@@ -7999,18 +7998,18 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -8129,7 +8128,7 @@ func IndexxOES(component int32) {
 func IndexxvOES(component *int32) {
 	C.glowIndexxvOES(gpIndexxvOES, (*C.GLfixed)(unsafe.Pointer(component)))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -8200,7 +8199,7 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -8272,7 +8271,7 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightModelxOES(pname uint32, param int32) {
@@ -8531,7 +8530,7 @@ func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width 
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 func Normal3xOES(nx int32, ny int32, nz int32) {
@@ -8542,18 +8541,18 @@ func Normal3xvOES(coords *int32) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func OrthofOES(l float32, r float32, b float32, t float32, n float32, f float32) {
@@ -8991,13 +8990,13 @@ func ProvokingVertex(mode uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -9143,7 +9142,7 @@ func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsa
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -9437,7 +9436,7 @@ func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offse
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TranslatexOES(x int32, y int32, z int32) {

--- a/gl-core/3.3/gl/conversions.go
+++ b/gl-core/3.3/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-core/3.3/gl/package.go
+++ b/gl-core/3.3/gl/package.go
@@ -3823,10 +3823,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -6436,7 +6435,7 @@ func BeginTransformFeedback(primitiveMode uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -6466,12 +6465,12 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -6776,7 +6775,7 @@ func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 func CompileShader(shader uint32) {
 	C.glowCompileShader(gpCompileShader, (C.GLuint)(shader))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -6930,17 +6929,17 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -6995,13 +6994,13 @@ func DebugMessageControlKHR(source uint32, xtype uint32, severity uint32, count 
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 
@@ -7017,7 +7016,7 @@ func DeleteFencesNV(n int32, fences *uint32) {
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
 	C.glowDeleteFramebuffers(gpDeleteFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
@@ -7443,17 +7442,17 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -7461,12 +7460,12 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -7474,7 +7473,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -7489,7 +7488,7 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7545,15 +7544,15 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -7586,13 +7585,13 @@ func GetFloatv(pname uint32, data *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7700,10 +7699,10 @@ func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -7711,24 +7710,24 @@ func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -7737,13 +7736,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -7752,10 +7751,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapxv(xmap uint32, size int32, values *int32) {
@@ -7776,7 +7775,7 @@ func GetProgramBinary(program uint32, bufSize int32, length *int32, binaryFormat
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -7784,10 +7783,10 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -7798,25 +7797,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
@@ -7871,7 +7870,7 @@ func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -7881,7 +7880,7 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
 
@@ -7901,13 +7900,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7989,7 +7988,7 @@ func GetTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int3
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbacki64_v(xfb uint32, pname uint32, index uint32, param *int64) {
@@ -8005,18 +8004,18 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -8135,7 +8134,7 @@ func IndexxOES(component int32) {
 func IndexxvOES(component *int32) {
 	C.glowIndexxvOES(gpIndexxvOES, (*C.GLfixed)(unsafe.Pointer(component)))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -8206,7 +8205,7 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -8278,7 +8277,7 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightModelxOES(pname uint32, param int32) {
@@ -8537,7 +8536,7 @@ func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width 
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 func Normal3xOES(nx int32, ny int32, nz int32) {
@@ -8548,18 +8547,18 @@ func Normal3xvOES(coords *int32) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func OrthofOES(l float32, r float32, b float32, t float32, n float32, f float32) {
@@ -8997,13 +8996,13 @@ func ProvokingVertex(mode uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -9149,7 +9148,7 @@ func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsa
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -9443,7 +9442,7 @@ func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offse
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TranslatexOES(x int32, y int32, z int32) {

--- a/gl-core/4.1/gl/conversions.go
+++ b/gl-core/4.1/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-core/4.1/gl/package.go
+++ b/gl-core/4.1/gl/package.go
@@ -3843,10 +3843,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -6470,7 +6469,7 @@ func BeginTransformFeedback(primitiveMode uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -6500,12 +6499,12 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -6822,7 +6821,7 @@ func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 func CompileShader(shader uint32) {
 	C.glowCompileShader(gpCompileShader, (C.GLuint)(shader))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -6976,17 +6975,17 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -7041,13 +7040,13 @@ func DebugMessageControlKHR(source uint32, xtype uint32, severity uint32, count 
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 
@@ -7063,7 +7062,7 @@ func DeleteFencesNV(n int32, fences *uint32) {
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
 	C.glowDeleteFramebuffers(gpDeleteFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
@@ -7489,17 +7488,17 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -7507,12 +7506,12 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -7520,7 +7519,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -7535,7 +7534,7 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7591,15 +7590,15 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -7632,13 +7631,13 @@ func GetFloatv(pname uint32, data *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7746,10 +7745,10 @@ func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -7757,24 +7756,24 @@ func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -7783,13 +7782,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -7798,10 +7797,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapxv(xmap uint32, size int32, values *int32) {
@@ -7822,7 +7821,7 @@ func GetProgramBinary(program uint32, bufSize int32, length *int32, binaryFormat
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -7830,10 +7829,10 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -7844,25 +7843,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
@@ -7917,7 +7916,7 @@ func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -7927,7 +7926,7 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
 
@@ -7947,13 +7946,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -8035,7 +8034,7 @@ func GetTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int3
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbacki64_v(xfb uint32, pname uint32, index uint32, param *int64) {
@@ -8051,18 +8050,18 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -8181,7 +8180,7 @@ func IndexxOES(component int32) {
 func IndexxvOES(component *int32) {
 	C.glowIndexxvOES(gpIndexxvOES, (*C.GLfixed)(unsafe.Pointer(component)))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -8252,7 +8251,7 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -8324,7 +8323,7 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightModelxOES(pname uint32, param int32) {
@@ -8588,7 +8587,7 @@ func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width 
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 func Normal3xOES(nx int32, ny int32, nz int32) {
@@ -8599,18 +8598,18 @@ func Normal3xvOES(coords *int32) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func OrthofOES(l float32, r float32, b float32, t float32, n float32, f float32) {
@@ -9048,13 +9047,13 @@ func ProvokingVertex(mode uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -9200,7 +9199,7 @@ func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsa
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -9494,7 +9493,7 @@ func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offse
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TranslatexOES(x int32, y int32, z int32) {

--- a/gl-core/4.4/gl/conversions.go
+++ b/gl-core/4.4/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-core/4.4/gl/package.go
+++ b/gl-core/4.4/gl/package.go
@@ -3843,10 +3843,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -6480,7 +6479,7 @@ func BeginTransformFeedback(primitiveMode uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -6510,12 +6509,12 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -6832,7 +6831,7 @@ func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 func CompileShader(shader uint32) {
 	C.glowCompileShader(gpCompileShader, (C.GLuint)(shader))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -6986,17 +6985,17 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -7051,13 +7050,13 @@ func DebugMessageControlKHR(source uint32, xtype uint32, severity uint32, count 
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 
@@ -7073,7 +7072,7 @@ func DeleteFencesNV(n int32, fences *uint32) {
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
 	C.glowDeleteFramebuffers(gpDeleteFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
@@ -7499,17 +7498,17 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -7517,12 +7516,12 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -7530,7 +7529,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -7545,7 +7544,7 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7601,15 +7600,15 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -7642,13 +7641,13 @@ func GetFloatv(pname uint32, data *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7756,10 +7755,10 @@ func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -7767,24 +7766,24 @@ func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -7793,13 +7792,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -7808,10 +7807,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapxv(xmap uint32, size int32, values *int32) {
@@ -7832,7 +7831,7 @@ func GetProgramBinary(program uint32, bufSize int32, length *int32, binaryFormat
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -7840,10 +7839,10 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -7854,25 +7853,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
@@ -7927,7 +7926,7 @@ func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -7937,7 +7936,7 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
 
@@ -7957,13 +7956,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -8045,7 +8044,7 @@ func GetTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int3
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbacki64_v(xfb uint32, pname uint32, index uint32, param *int64) {
@@ -8061,18 +8060,18 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -8191,7 +8190,7 @@ func IndexxOES(component int32) {
 func IndexxvOES(component *int32) {
 	C.glowIndexxvOES(gpIndexxvOES, (*C.GLfixed)(unsafe.Pointer(component)))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -8262,7 +8261,7 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -8334,7 +8333,7 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightModelxOES(pname uint32, param int32) {
@@ -8598,7 +8597,7 @@ func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width 
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 func Normal3xOES(nx int32, ny int32, nz int32) {
@@ -8609,18 +8608,18 @@ func Normal3xvOES(coords *int32) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func OrthofOES(l float32, r float32, b float32, t float32, n float32, f float32) {
@@ -9058,13 +9057,13 @@ func ProvokingVertex(mode uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -9210,7 +9209,7 @@ func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsa
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -9504,7 +9503,7 @@ func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offse
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TranslatexOES(x int32, y int32, z int32) {

--- a/gl-core/4.5/gl/conversions.go
+++ b/gl-core/4.5/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-core/4.5/gl/package.go
+++ b/gl-core/4.5/gl/package.go
@@ -3855,10 +3855,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -6496,7 +6495,7 @@ func BeginTransformFeedback(primitiveMode uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -6526,12 +6525,12 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -6848,7 +6847,7 @@ func ColorMaski(index uint32, r bool, g bool, b bool, a bool) {
 func CompileShader(shader uint32) {
 	C.glowCompileShader(gpCompileShader, (C.GLuint)(shader))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -7002,17 +7001,17 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -7067,13 +7066,13 @@ func DebugMessageControlKHR(source uint32, xtype uint32, severity uint32, count 
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 
@@ -7089,7 +7088,7 @@ func DeleteFencesNV(n int32, fences *uint32) {
 func DeleteFramebuffers(n int32, framebuffers *uint32) {
 	C.glowDeleteFramebuffers(gpDeleteFramebuffers, (C.GLsizei)(n), (*C.GLuint)(unsafe.Pointer(framebuffers)))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
@@ -7515,17 +7514,17 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -7533,12 +7532,12 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -7546,7 +7545,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -7561,7 +7560,7 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7617,15 +7616,15 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -7658,13 +7657,13 @@ func GetFloatv(pname uint32, data *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -7772,10 +7771,10 @@ func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -7783,24 +7782,24 @@ func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -7809,13 +7808,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -7824,10 +7823,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapxv(xmap uint32, size int32, values *int32) {
@@ -7848,7 +7847,7 @@ func GetProgramBinary(program uint32, bufSize int32, length *int32, binaryFormat
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -7856,10 +7855,10 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -7870,25 +7869,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
@@ -7943,7 +7942,7 @@ func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -7953,7 +7952,7 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
 
@@ -7973,13 +7972,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -8061,7 +8060,7 @@ func GetTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int3
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbacki64_v(xfb uint32, pname uint32, index uint32, param *int64) {
@@ -8077,18 +8076,18 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -8220,7 +8219,7 @@ func IndexxOES(component int32) {
 func IndexxvOES(component *int32) {
 	C.glowIndexxvOES(gpIndexxvOES, (*C.GLfixed)(unsafe.Pointer(component)))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -8291,7 +8290,7 @@ func IsImageHandleResidentARB(handle uint64) bool {
 	ret := C.glowIsImageHandleResidentARB(gpIsImageHandleResidentARB, (C.GLuint64)(handle))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -8363,7 +8362,7 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightModelxOES(pname uint32, param int32) {
@@ -8627,7 +8626,7 @@ func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width 
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 func Normal3xOES(nx int32, ny int32, nz int32) {
@@ -8638,18 +8637,18 @@ func Normal3xvOES(coords *int32) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func OrthofOES(l float32, r float32, b float32, t float32, n float32, f float32) {
@@ -9087,13 +9086,13 @@ func ProvokingVertex(mode uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -9239,7 +9238,7 @@ func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsa
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -9533,7 +9532,7 @@ func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offse
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TranslatexOES(x int32, y int32, z int32) {

--- a/gl-core/all/gl/conversions.go
+++ b/gl-core/all/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl-core/all/gl/package.go
+++ b/gl-core/all/gl/package.go
@@ -5250,10 +5250,9 @@ package gl
 // }
 import "C"
 import (
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -8691,7 +8690,7 @@ func BeginTransformFeedback(primitiveMode uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -8721,12 +8720,12 @@ func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32,
 }
 
 // bind a user-defined varying out variable to a fragment shader color number
-func BindFragDataLocation(program uint32, color uint32, name *int8) {
+func BindFragDataLocation(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocation(gpBindFragDataLocation, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
@@ -9184,7 +9183,7 @@ func ColorPointer(size int32, xtype uint32, stride int32, pointer unsafe.Pointer
 func CompileShader(shader uint32) {
 	C.glowCompileShader(gpCompileShader, (C.GLuint)(shader))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -9343,17 +9342,17 @@ func CreateShader(xtype uint32) uint32 {
 	ret := C.glowCreateShader(gpCreateShader, (C.GLenum)(xtype))
 	return (uint32)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -9408,13 +9407,13 @@ func DebugMessageControlKHR(source uint32, xtype uint32, severity uint32, count 
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 
@@ -9435,7 +9434,7 @@ func DeleteFramebuffers(n int32, framebuffers *uint32) {
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeletePerfMonitorsAMD(n int32, monitors *uint32) {
@@ -9974,17 +9973,17 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -9992,12 +9991,12 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -10005,7 +10004,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -10020,7 +10019,7 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -10081,15 +10080,15 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -10122,13 +10121,13 @@ func GetFloatv(pname uint32, data *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the bindings of color numbers to user-defined varying out variables
-func GetFragDataLocation(program uint32, name *int8) int32 {
+func GetFragDataLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocation(gpGetFragDataLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -10257,10 +10256,10 @@ func GetNamedFramebufferParameteriv(framebuffer uint32, pname uint32, param *int
 func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameteriv(gpGetNamedRenderbufferParameteriv, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -10268,24 +10267,24 @@ func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -10294,13 +10293,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -10309,10 +10308,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapfv(xmap uint32, values *float32) {
@@ -10347,7 +10346,7 @@ func GetProgramBinary(program uint32, bufSize int32, length *int32, binaryFormat
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -10355,10 +10354,10 @@ func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -10369,25 +10368,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourceiv(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *int32) {
@@ -10442,7 +10441,7 @@ func GetSamplerParameteriv(sampler uint32, pname uint32, params *int32) {
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -10452,7 +10451,7 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
 
@@ -10472,13 +10471,13 @@ func GetStringi(name uint32, index uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -10575,7 +10574,7 @@ func GetTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int3
 }
 
 // retrieve information about varying variables selected for transform feedback
-func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVarying(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVarying(gpGetTransformFeedbackVarying, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbacki64_v(xfb uint32, pname uint32, index uint32, param *int64) {
@@ -10591,18 +10590,18 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -10779,7 +10778,7 @@ func IndexxvOES(component *int32) {
 func InitNames() {
 	C.glowInitNames(gpInitNames)
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -10861,7 +10860,7 @@ func IsList(list uint32) bool {
 	ret := C.glowIsList(gpIsList, (C.GLuint)(list))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -10933,7 +10932,7 @@ func IsVertexArray(array uint32) bool {
 	ret := C.glowIsVertexArray(gpIsVertexArray, (C.GLuint)(array))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightModelf(pname uint32, param float32) {
@@ -11402,7 +11401,7 @@ func NamedRenderbufferStorage(renderbuffer uint32, internalformat uint32, width 
 func NamedRenderbufferStorageMultisample(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisample(gpNamedRenderbufferStorageMultisample, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 
@@ -11453,18 +11452,18 @@ func NormalPointer(xtype uint32, stride int32, pointer unsafe.Pointer) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
@@ -11964,13 +11963,13 @@ func PushClientAttrib(mask uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -12303,7 +12302,7 @@ func ShaderBinary(count int32, shaders *uint32, binaryformat uint32, binary unsa
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -12728,7 +12727,7 @@ func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offse
 }
 
 // specify values to record in transform feedback buffers
-func TransformFeedbackVaryings(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryings(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryings(gpTransformFeedbackVaryings, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func Translated(x float64, y float64, z float64) {

--- a/gl/2.1/gl/conversions.go
+++ b/gl/2.1/gl/conversions.go
@@ -50,12 +50,12 @@ func PtrOffset(offset int) unsafe.Pointer {
 // Str takes a null-terminated Go string and returns its GL-compatible address.
 // This function reaches into Go string storage in an unsafe way so the caller
 // must ensure the string is not garbage collected.
-func Str(str string) *int8 {
+func Str(str string) *uint8 {
 	if !strings.HasSuffix(str, "\x00") {
 		log.Fatal("str argument missing null terminator", str)
 	}
 	header := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	return (*int8)(unsafe.Pointer(header.Data))
+	return (*uint8)(unsafe.Pointer(header.Data))
 }
 
 // GoStr takes a null-terminated string returned by OpenGL and constructs a

--- a/gl/2.1/gl/package.go
+++ b/gl/2.1/gl/package.go
@@ -10692,10 +10692,9 @@ package gl
 import "C"
 import (
 	"errors"
-	"unsafe"
-
 	"github.com/go-gl/glow/procaddr"
 	"github.com/go-gl/glow/procaddr/auto"
+	"unsafe"
 )
 
 const (
@@ -17840,7 +17839,7 @@ func ActiveTexture(texture uint32) {
 func ActiveTextureARB(texture uint32) {
 	C.glowActiveTextureARB(gpActiveTextureARB, (C.GLenum)(texture))
 }
-func ActiveVaryingNV(program uint32, name *int8) {
+func ActiveVaryingNV(program uint32, name *uint8) {
 	C.glowActiveVaryingNV(gpActiveVaryingNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func AlphaFragmentOp1ATI(op uint32, dst uint32, dstMod uint32, arg1 uint32, arg1Rep uint32, arg1Mod uint32) {
@@ -17947,10 +17946,10 @@ func BeginVideoCaptureNV(video_capture_slot uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *int8) {
+func BindAttribLocation(program uint32, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func BindAttribLocationARB(programObj uintptr, index uint32, name *int8) {
+func BindAttribLocationARB(programObj uintptr, index uint32, name *uint8) {
 	C.glowBindAttribLocationARB(gpBindAttribLocationARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
@@ -17989,12 +17988,12 @@ func BindBuffersBase(target uint32, first uint32, count int32, buffers *uint32) 
 func BindBuffersRange(target uint32, first uint32, count int32, buffers *uint32, offsets *int, sizes *int) {
 	C.glowBindBuffersRange(gpBindBuffersRange, (C.GLenum)(target), (C.GLuint)(first), (C.GLsizei)(count), (*C.GLuint)(unsafe.Pointer(buffers)), (*C.GLintptr)(unsafe.Pointer(offsets)), (*C.GLsizeiptr)(unsafe.Pointer(sizes)))
 }
-func BindFragDataLocationEXT(program uint32, color uint32, name *int8) {
+func BindFragDataLocationEXT(program uint32, color uint32, name *uint8) {
 	C.glowBindFragDataLocationEXT(gpBindFragDataLocationEXT, (C.GLuint)(program), (C.GLuint)(color), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a user-defined varying out variable to a fragment shader color number and index
-func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *int8) {
+func BindFragDataLocationIndexed(program uint32, colorNumber uint32, index uint32, name *uint8) {
 	C.glowBindFragDataLocationIndexed(gpBindFragDataLocationIndexed, (C.GLuint)(program), (C.GLuint)(colorNumber), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func BindFragmentShaderATI(id uint32) {
@@ -18685,7 +18684,7 @@ func CompileShader(shader uint32) {
 func CompileShaderARB(shaderObj uintptr) {
 	C.glowCompileShaderARB(gpCompileShaderARB, (C.GLhandleARB)(shaderObj))
 }
-func CompileShaderIncludeARB(shader uint32, count int32, path **int8, length *int32) {
+func CompileShaderIncludeARB(shader uint32, count int32, path **uint8, length *int32) {
 	C.glowCompileShaderIncludeARB(gpCompileShaderIncludeARB, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(path)), (*C.GLint)(unsafe.Pointer(length)))
 }
 func CompressedMultiTexImage1DEXT(texunit uint32, target uint32, level int32, internalformat uint32, width int32, border int32, imageSize int32, bits unsafe.Pointer) {
@@ -18999,17 +18998,17 @@ func CreateShaderObjectARB(shaderType uint32) uintptr {
 	ret := C.glowCreateShaderObjectARB(gpCreateShaderObjectARB, (C.GLenum)(shaderType))
 	return (uintptr)(ret)
 }
-func CreateShaderProgramEXT(xtype uint32, xstring *int8) uint32 {
+func CreateShaderProgramEXT(xtype uint32, xstring *uint8) uint32 {
 	ret := C.glowCreateShaderProgramEXT(gpCreateShaderProgramEXT, (C.GLenum)(xtype), (*C.GLchar)(unsafe.Pointer(xstring)))
 	return (uint32)(ret)
 }
 
 // create a stand-alone program from an array of null-terminated source code strings
-func CreateShaderProgramv(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramv(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramv(gpCreateShaderProgramv, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
-func CreateShaderProgramvEXT(xtype uint32, count int32, strings **int8) uint32 {
+func CreateShaderProgramvEXT(xtype uint32, count int32, strings **uint8) uint32 {
 	ret := C.glowCreateShaderProgramvEXT(gpCreateShaderProgramvEXT, (C.GLenum)(xtype), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(strings)))
 	return (uint32)(ret)
 }
@@ -19079,16 +19078,16 @@ func DebugMessageEnableAMD(category uint32, severity uint32, count int32, ids *u
 }
 
 // inject an application-supplied message into the debug message queue
-func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsert(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsert(gpDebugMessageInsert, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *int8) {
+func DebugMessageInsertAMD(category uint32, severity uint32, id uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertAMD(gpDebugMessageInsertAMD, (C.GLenum)(category), (C.GLenum)(severity), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertARB(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertARB(gpDebugMessageInsertARB, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
-func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *int8) {
+func DebugMessageInsertKHR(source uint32, xtype uint32, id uint32, severity uint32, length int32, buf *uint8) {
 	C.glowDebugMessageInsertKHR(gpDebugMessageInsertKHR, (C.GLenum)(source), (C.GLenum)(xtype), (C.GLuint)(id), (C.GLenum)(severity), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(buf)))
 }
 func DeformSGIX(mask uint32) {
@@ -19133,7 +19132,7 @@ func DeleteFramebuffersEXT(n int32, framebuffers *uint32) {
 func DeleteLists(list uint32, xrange int32) {
 	C.glowDeleteLists(gpDeleteLists, (C.GLuint)(list), (C.GLsizei)(xrange))
 }
-func DeleteNamedStringARB(namelen int32, name *int8) {
+func DeleteNamedStringARB(namelen int32, name *uint8) {
 	C.glowDeleteNamedStringARB(gpDeleteNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func DeleteNamesAMD(identifier uint32, num uint32, names *uint32) {
@@ -20053,20 +20052,20 @@ func GetActiveAtomicCounterBufferiv(program uint32, bufferIndex uint32, pname ui
 }
 
 // Returns information about an active attribute variable for the specified program object
-func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttrib(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttrib(gpGetActiveAttrib, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveAttribARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveAttribARB(gpGetActiveAttribARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine
-func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineName(gpGetActiveSubroutineName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // query the name of an active shader subroutine uniform
-func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *int8) {
+func GetActiveSubroutineUniformName(program uint32, shadertype uint32, index uint32, bufsize int32, length *int32, name *uint8) {
 	C.glowGetActiveSubroutineUniformName(gpGetActiveSubroutineUniformName, (C.GLuint)(program), (C.GLenum)(shadertype), (C.GLuint)(index), (C.GLsizei)(bufsize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint32, pname uint32, values *int32) {
@@ -20074,15 +20073,15 @@ func GetActiveSubroutineUniformiv(program uint32, shadertype uint32, index uint3
 }
 
 // Returns information about an active uniform variable for the specified program object
-func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniform(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniform(gpGetActiveUniform, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
-func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveUniformARB(programObj uintptr, index uint32, maxLength int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveUniformARB(gpGetActiveUniformARB, (C.GLhandleARB)(programObj), (C.GLuint)(index), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLint)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLcharARB)(unsafe.Pointer(name)))
 }
 
 // retrieve the name of an active uniform block
-func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *int8) {
+func GetActiveUniformBlockName(program uint32, uniformBlockIndex uint32, bufSize int32, length *int32, uniformBlockName *uint8) {
 	C.glowGetActiveUniformBlockName(gpGetActiveUniformBlockName, (C.GLuint)(program), (C.GLuint)(uniformBlockIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 }
 func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uint32, params *int32) {
@@ -20090,7 +20089,7 @@ func GetActiveUniformBlockiv(program uint32, uniformBlockIndex uint32, pname uin
 }
 
 // query the name of an active uniform
-func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *int8) {
+func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, length *int32, uniformName *uint8) {
 	C.glowGetActiveUniformName(gpGetActiveUniformName, (C.GLuint)(program), (C.GLuint)(uniformIndex), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(uniformName)))
 }
 
@@ -20098,7 +20097,7 @@ func GetActiveUniformName(program uint32, uniformIndex uint32, bufSize int32, le
 func GetActiveUniformsiv(program uint32, uniformCount int32, uniformIndices *uint32, pname uint32, params *int32) {
 	C.glowGetActiveUniformsiv(gpGetActiveUniformsiv, (C.GLuint)(program), (C.GLsizei)(uniformCount), (*C.GLuint)(unsafe.Pointer(uniformIndices)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetActiveVaryingNV(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetActiveVaryingNV(gpGetActiveVaryingNV, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetArrayObjectfvATI(array uint32, pname uint32, params *float32) {
@@ -20117,11 +20116,11 @@ func GetAttachedShaders(program uint32, maxCount int32, count *int32, shaders *u
 }
 
 // Returns the location of an attribute variable
-func GetAttribLocation(program uint32, name *int8) int32 {
+func GetAttribLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetAttribLocation(gpGetAttribLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetAttribLocationARB(programObj uintptr, name *int8) int32 {
+func GetAttribLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetAttribLocationARB(gpGetAttribLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -20240,19 +20239,19 @@ func GetConvolutionParameterxvOES(target uint32, pname uint32, params *int32) {
 }
 
 // retrieve messages from the debug message log
-func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLog(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLog(gpGetDebugMessageLog, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *int8) uint32 {
+func GetDebugMessageLogAMD(count uint32, bufsize int32, categories *uint32, severities *uint32, ids *uint32, lengths *int32, message *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogAMD(gpGetDebugMessageLogAMD, (C.GLuint)(count), (C.GLsizei)(bufsize), (*C.GLenum)(unsafe.Pointer(categories)), (*C.GLuint)(unsafe.Pointer(severities)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(message)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogARB(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogARB(gpGetDebugMessageLogARB, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
-func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *int8) uint32 {
+func GetDebugMessageLogKHR(count uint32, bufSize int32, sources *uint32, types *uint32, ids *uint32, severities *uint32, lengths *int32, messageLog *uint8) uint32 {
 	ret := C.glowGetDebugMessageLogKHR(gpGetDebugMessageLogKHR, (C.GLuint)(count), (C.GLsizei)(bufSize), (*C.GLenum)(unsafe.Pointer(sources)), (*C.GLenum)(unsafe.Pointer(types)), (*C.GLuint)(unsafe.Pointer(ids)), (*C.GLenum)(unsafe.Pointer(severities)), (*C.GLsizei)(unsafe.Pointer(lengths)), (*C.GLchar)(unsafe.Pointer(messageLog)))
 	return (uint32)(ret)
 }
@@ -20309,11 +20308,11 @@ func GetFogFuncSGIS(points *float32) {
 }
 
 // query the bindings of color indices to user-defined varying out variables
-func GetFragDataIndex(program uint32, name *int8) int32 {
+func GetFragDataIndex(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataIndex(gpGetFragDataIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetFragDataLocationEXT(program uint32, name *int8) int32 {
+func GetFragDataLocationEXT(program uint32, name *uint8) int32 {
 	ret := C.glowGetFragDataLocationEXT(gpGetFragDataLocationEXT, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -20389,7 +20388,7 @@ func GetImageTransformParameterfvHP(target uint32, pname uint32, params *float32
 func GetImageTransformParameterivHP(target uint32, pname uint32, params *int32) {
 	C.glowGetImageTransformParameterivHP(gpGetImageTransformParameterivHP, (C.GLenum)(target), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *int8) {
+func GetInfoLogARB(obj uintptr, maxLength int32, length *int32, infoLog *uint8) {
 	C.glowGetInfoLogARB(gpGetInfoLogARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(infoLog)))
 }
 func GetInstrumentsSGIX() int32 {
@@ -20619,10 +20618,10 @@ func GetNamedRenderbufferParameteriv(renderbuffer uint32, pname uint32, params *
 func GetNamedRenderbufferParameterivEXT(renderbuffer uint32, pname uint32, params *int32) {
 	C.glowGetNamedRenderbufferParameterivEXT(gpGetNamedRenderbufferParameterivEXT, (C.GLuint)(renderbuffer), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetNamedStringARB(namelen int32, name *int8, bufSize int32, stringlen *int32, xstring *int8) {
+func GetNamedStringARB(namelen int32, name *uint8, bufSize int32, stringlen *int32, xstring *uint8) {
 	C.glowGetNamedStringARB(gpGetNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLsizei)(bufSize), (*C.GLint)(unsafe.Pointer(stringlen)), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
-func GetNamedStringivARB(namelen int32, name *int8, pname uint32, params *int32) {
+func GetNamedStringivARB(namelen int32, name *uint8, pname uint32, params *int32) {
 	C.glowGetNamedStringivARB(gpGetNamedStringivARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
 func GetNextPerfQueryIdINTEL(queryId uint32, nextQueryId *uint32) {
@@ -20636,13 +20635,13 @@ func GetObjectBufferivATI(buffer uint32, pname uint32, params *int32) {
 }
 
 // retrieve the label of a named object identified within a namespace
-func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabel(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabel(gpGetObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelEXT(xtype uint32, object uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelEXT(gpGetObjectLabelEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *int8) {
+func GetObjectLabelKHR(identifier uint32, name uint32, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectLabelKHR(gpGetObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetObjectParameterfvARB(obj uintptr, pname uint32, params *float32) {
@@ -20656,10 +20655,10 @@ func GetObjectParameterivARB(obj uintptr, pname uint32, params *int32) {
 }
 
 // retrieve the label of a sync object identified by a pointer
-func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabel(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabel(gpGetObjectPtrLabel, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *int8) {
+func GetObjectPtrLabelKHR(ptr unsafe.Pointer, bufSize int32, length *int32, label *uint8) {
 	C.glowGetObjectPtrLabelKHR(gpGetObjectPtrLabelKHR, ptr, (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func GetOcclusionQueryivNV(id uint32, pname uint32, params *int32) {
@@ -20708,7 +20707,7 @@ func GetPathTexGenfvNV(texCoordSet uint32, pname uint32, value *float32) {
 func GetPathTexGenivNV(texCoordSet uint32, pname uint32, value *int32) {
 	C.glowGetPathTexGenivNV(gpGetPathTexGenivNV, (C.GLenum)(texCoordSet), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(value)))
 }
-func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *int8, counterDescLength uint32, counterDesc *int8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
+func GetPerfCounterInfoINTEL(queryId uint32, counterId uint32, counterNameLength uint32, counterName *uint8, counterDescLength uint32, counterDesc *uint8, counterOffset *uint32, counterDataSize *uint32, counterTypeEnum *uint32, counterDataTypeEnum *uint32, rawCounterMaxValue *uint64) {
 	C.glowGetPerfCounterInfoINTEL(gpGetPerfCounterInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(counterId), (C.GLuint)(counterNameLength), (*C.GLchar)(unsafe.Pointer(counterName)), (C.GLuint)(counterDescLength), (*C.GLchar)(unsafe.Pointer(counterDesc)), (*C.GLuint)(unsafe.Pointer(counterOffset)), (*C.GLuint)(unsafe.Pointer(counterDataSize)), (*C.GLuint)(unsafe.Pointer(counterTypeEnum)), (*C.GLuint)(unsafe.Pointer(counterDataTypeEnum)), (*C.GLuint64)(unsafe.Pointer(rawCounterMaxValue)))
 }
 func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, data *uint32, bytesWritten *int32) {
@@ -20717,13 +20716,13 @@ func GetPerfMonitorCounterDataAMD(monitor uint32, pname uint32, dataSize int32, 
 func GetPerfMonitorCounterInfoAMD(group uint32, counter uint32, pname uint32, data unsafe.Pointer) {
 	C.glowGetPerfMonitorCounterInfoAMD(gpGetPerfMonitorCounterInfoAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLenum)(pname), data)
 }
-func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *int8) {
+func GetPerfMonitorCounterStringAMD(group uint32, counter uint32, bufSize int32, length *int32, counterString *uint8) {
 	C.glowGetPerfMonitorCounterStringAMD(gpGetPerfMonitorCounterStringAMD, (C.GLuint)(group), (C.GLuint)(counter), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(counterString)))
 }
 func GetPerfMonitorCountersAMD(group uint32, numCounters *int32, maxActiveCounters *int32, counterSize int32, counters *uint32) {
 	C.glowGetPerfMonitorCountersAMD(gpGetPerfMonitorCountersAMD, (C.GLuint)(group), (*C.GLint)(unsafe.Pointer(numCounters)), (*C.GLint)(unsafe.Pointer(maxActiveCounters)), (C.GLsizei)(counterSize), (*C.GLuint)(unsafe.Pointer(counters)))
 }
-func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *int8) {
+func GetPerfMonitorGroupStringAMD(group uint32, bufSize int32, length *int32, groupString *uint8) {
 	C.glowGetPerfMonitorGroupStringAMD(gpGetPerfMonitorGroupStringAMD, (C.GLuint)(group), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(groupString)))
 }
 func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32) {
@@ -20732,10 +20731,10 @@ func GetPerfMonitorGroupsAMD(numGroups *int32, groupsSize int32, groups *uint32)
 func GetPerfQueryDataINTEL(queryHandle uint32, flags uint32, dataSize int32, data unsafe.Pointer, bytesWritten *uint32) {
 	C.glowGetPerfQueryDataINTEL(gpGetPerfQueryDataINTEL, (C.GLuint)(queryHandle), (C.GLuint)(flags), (C.GLsizei)(dataSize), data, (*C.GLuint)(unsafe.Pointer(bytesWritten)))
 }
-func GetPerfQueryIdByNameINTEL(queryName *int8, queryId *uint32) {
+func GetPerfQueryIdByNameINTEL(queryName *uint8, queryId *uint32) {
 	C.glowGetPerfQueryIdByNameINTEL(gpGetPerfQueryIdByNameINTEL, (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(queryId)))
 }
-func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *int8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
+func GetPerfQueryInfoINTEL(queryId uint32, queryNameLength uint32, queryName *uint8, dataSize *uint32, noCounters *uint32, noInstances *uint32, capsMask *uint32) {
 	C.glowGetPerfQueryInfoINTEL(gpGetPerfQueryInfoINTEL, (C.GLuint)(queryId), (C.GLuint)(queryNameLength), (*C.GLchar)(unsafe.Pointer(queryName)), (*C.GLuint)(unsafe.Pointer(dataSize)), (*C.GLuint)(unsafe.Pointer(noCounters)), (*C.GLuint)(unsafe.Pointer(noInstances)), (*C.GLuint)(unsafe.Pointer(capsMask)))
 }
 func GetPixelMapfv(xmap uint32, values *float32) {
@@ -20803,7 +20802,7 @@ func GetProgramEnvParameterfvARB(target uint32, index uint32, params *float32) {
 }
 
 // Returns the information log for a program object
-func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramInfoLog(program uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramInfoLog(gpGetProgramInfoLog, (C.GLuint)(program), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramInterfaceiv(program uint32, programInterface uint32, pname uint32, params *int32) {
@@ -20835,10 +20834,10 @@ func GetProgramParameterfvNV(target uint32, index uint32, pname uint32, params *
 }
 
 // retrieve the info log string from a program pipeline object
-func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLog(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLog(gpGetProgramPipelineInfoLog, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
-func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetProgramPipelineInfoLogEXT(pipeline uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetProgramPipelineInfoLogEXT(gpGetProgramPipelineInfoLogEXT, (C.GLuint)(pipeline), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 func GetProgramPipelineiv(pipeline uint32, pname uint32, params *int32) {
@@ -20849,25 +20848,25 @@ func GetProgramPipelineivEXT(pipeline uint32, pname uint32, params *int32) {
 }
 
 // query the index of a named resource within a program
-func GetProgramResourceIndex(program uint32, programInterface uint32, name *int8) uint32 {
+func GetProgramResourceIndex(program uint32, programInterface uint32, name *uint8) uint32 {
 	ret := C.glowGetProgramResourceIndex(gpGetProgramResourceIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // query the location of a named resource within a program
-func GetProgramResourceLocation(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocation(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocation(gpGetProgramResourceLocation, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the fragment color index of a named variable within a program
-func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *int8) int32 {
+func GetProgramResourceLocationIndex(program uint32, programInterface uint32, name *uint8) int32 {
 	ret := C.glowGetProgramResourceLocationIndex(gpGetProgramResourceLocationIndex, (C.GLuint)(program), (C.GLenum)(programInterface), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
 
 // query the name of an indexed resource within a program
-func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *int8) {
+func GetProgramResourceName(program uint32, programInterface uint32, index uint32, bufSize int32, length *int32, name *uint8) {
 	C.glowGetProgramResourceName(gpGetProgramResourceName, (C.GLuint)(program), (C.GLenum)(programInterface), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetProgramResourcefvNV(program uint32, programInterface uint32, index uint32, propCount int32, props *uint32, bufSize int32, length *int32, params *float32) {
@@ -20961,7 +20960,7 @@ func GetSeparableFilterEXT(target uint32, format uint32, xtype uint32, row unsaf
 }
 
 // Returns the information log for a shader object
-func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *int8) {
+func GetShaderInfoLog(shader uint32, bufSize int32, length *int32, infoLog *uint8) {
 	C.glowGetShaderInfoLog(gpGetShaderInfoLog, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(infoLog)))
 }
 
@@ -20971,10 +20970,10 @@ func GetShaderPrecisionFormat(shadertype uint32, precisiontype uint32, xrange *i
 }
 
 // Returns the source code string from a shader object
-func GetShaderSource(shader uint32, bufSize int32, length *int32, source *int8) {
+func GetShaderSource(shader uint32, bufSize int32, length *int32, source *uint8) {
 	C.glowGetShaderSource(gpGetShaderSource, (C.GLuint)(shader), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLchar)(unsafe.Pointer(source)))
 }
-func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *int8) {
+func GetShaderSourceARB(obj uintptr, maxLength int32, length *int32, source *uint8) {
 	C.glowGetShaderSourceARB(gpGetShaderSourceARB, (C.GLhandleARB)(obj), (C.GLsizei)(maxLength), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLcharARB)(unsafe.Pointer(source)))
 }
 
@@ -20993,13 +20992,13 @@ func GetString(name uint32) *uint8 {
 }
 
 // retrieve the index of a subroutine uniform of a given shader stage within a program
-func GetSubroutineIndex(program uint32, shadertype uint32, name *int8) uint32 {
+func GetSubroutineIndex(program uint32, shadertype uint32, name *uint8) uint32 {
 	ret := C.glowGetSubroutineIndex(gpGetSubroutineIndex, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (uint32)(ret)
 }
 
 // retrieve the location of a subroutine uniform of a given shader stage within a program
-func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *int8) int32 {
+func GetSubroutineUniformLocation(program uint32, shadertype uint32, name *uint8) int32 {
 	ret := C.glowGetSubroutineUniformLocation(gpGetSubroutineUniformLocation, (C.GLuint)(program), (C.GLenum)(shadertype), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21138,7 +21137,7 @@ func GetTextureSubImage(texture uint32, level int32, xoffset int32, yoffset int3
 func GetTrackMatrixivNV(target uint32, address uint32, pname uint32, params *int32) {
 	C.glowGetTrackMatrixivNV(gpGetTrackMatrixivNV, (C.GLenum)(target), (C.GLuint)(address), (C.GLenum)(pname), (*C.GLint)(unsafe.Pointer(params)))
 }
-func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *int8) {
+func GetTransformFeedbackVaryingEXT(program uint32, index uint32, bufSize int32, length *int32, size *int32, xtype *uint32, name *uint8) {
 	C.glowGetTransformFeedbackVaryingEXT(gpGetTransformFeedbackVaryingEXT, (C.GLuint)(program), (C.GLuint)(index), (C.GLsizei)(bufSize), (*C.GLsizei)(unsafe.Pointer(length)), (*C.GLsizei)(unsafe.Pointer(size)), (*C.GLenum)(unsafe.Pointer(xtype)), (*C.GLchar)(unsafe.Pointer(name)))
 }
 func GetTransformFeedbackVaryingNV(program uint32, index uint32, location *int32) {
@@ -21157,7 +21156,7 @@ func GetTransformFeedbackiv(xfb uint32, pname uint32, param *int32) {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformBlockIndex(program uint32, uniformBlockName *int8) uint32 {
+func GetUniformBlockIndex(program uint32, uniformBlockName *uint8) uint32 {
 	ret := C.glowGetUniformBlockIndex(gpGetUniformBlockIndex, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(uniformBlockName)))
 	return (uint32)(ret)
 }
@@ -21167,16 +21166,16 @@ func GetUniformBufferSizeEXT(program uint32, location int32) int32 {
 }
 
 // retrieve the index of a named uniform block
-func GetUniformIndices(program uint32, uniformCount int32, uniformNames **int8, uniformIndices *uint32) {
+func GetUniformIndices(program uint32, uniformCount int32, uniformNames **uint8, uniformIndices *uint32) {
 	C.glowGetUniformIndices(gpGetUniformIndices, (C.GLuint)(program), (C.GLsizei)(uniformCount), (**C.GLchar)(unsafe.Pointer(uniformNames)), (*C.GLuint)(unsafe.Pointer(uniformIndices)))
 }
 
 // Returns the location of a uniform variable
-func GetUniformLocation(program uint32, name *int8) int32 {
+func GetUniformLocation(program uint32, name *uint8) int32 {
 	ret := C.glowGetUniformLocation(gpGetUniformLocation, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
-func GetUniformLocationARB(programObj uintptr, name *int8) int32 {
+func GetUniformLocationARB(programObj uintptr, name *uint8) int32 {
 	ret := C.glowGetUniformLocationARB(gpGetUniformLocationARB, (C.GLhandleARB)(programObj), (*C.GLcharARB)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21233,7 +21232,7 @@ func GetVariantIntegervEXT(id uint32, value uint32, data *int32) {
 func GetVariantPointervEXT(id uint32, value uint32, data *unsafe.Pointer) {
 	C.glowGetVariantPointervEXT(gpGetVariantPointervEXT, (C.GLuint)(id), (C.GLenum)(value), data)
 }
-func GetVaryingLocationNV(program uint32, name *int8) int32 {
+func GetVaryingLocationNV(program uint32, name *uint8) int32 {
 	ret := C.glowGetVaryingLocationNV(gpGetVaryingLocationNV, (C.GLuint)(program), (*C.GLchar)(unsafe.Pointer(name)))
 	return (int32)(ret)
 }
@@ -21516,7 +21515,7 @@ func InitNames() {
 func InsertComponentEXT(res uint32, src uint32, num uint32) {
 	C.glowInsertComponentEXT(gpInsertComponentEXT, (C.GLuint)(res), (C.GLuint)(src), (C.GLuint)(num))
 }
-func InsertEventMarkerEXT(length int32, marker *int8) {
+func InsertEventMarkerEXT(length int32, marker *uint8) {
 	C.glowInsertEventMarkerEXT(gpInsertEventMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 func InstrumentsBufferSGIX(size int32, buffer *int32) {
@@ -21636,7 +21635,7 @@ func IsNamedBufferResidentNV(buffer uint32) bool {
 	ret := C.glowIsNamedBufferResidentNV(gpIsNamedBufferResidentNV, (C.GLuint)(buffer))
 	return ret == TRUE
 }
-func IsNamedStringARB(namelen int32, name *int8) bool {
+func IsNamedStringARB(namelen int32, name *uint8) bool {
 	ret := C.glowIsNamedStringARB(gpIsNamedStringARB, (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)))
 	return ret == TRUE
 }
@@ -21768,7 +21767,7 @@ func IsVertexAttribEnabledAPPLE(index uint32, pname uint32) bool {
 	ret := C.glowIsVertexAttribEnabledAPPLE(gpIsVertexAttribEnabledAPPLE, (C.GLuint)(index), (C.GLenum)(pname))
 	return ret == TRUE
 }
-func LabelObjectEXT(xtype uint32, object uint32, length int32, label *int8) {
+func LabelObjectEXT(xtype uint32, object uint32, length int32, label *uint8) {
 	C.glowLabelObjectEXT(gpLabelObjectEXT, (C.GLenum)(xtype), (C.GLuint)(object), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func LightEnviSGIX(pname uint32, param int32) {
@@ -22735,7 +22734,7 @@ func NamedRenderbufferStorageMultisampleCoverageEXT(renderbuffer uint32, coverag
 func NamedRenderbufferStorageMultisampleEXT(renderbuffer uint32, samples int32, internalformat uint32, width int32, height int32) {
 	C.glowNamedRenderbufferStorageMultisampleEXT(gpNamedRenderbufferStorageMultisampleEXT, (C.GLuint)(renderbuffer), (C.GLsizei)(samples), (C.GLenum)(internalformat), (C.GLsizei)(width), (C.GLsizei)(height))
 }
-func NamedStringARB(xtype uint32, namelen int32, name *int8, stringlen int32, xstring *int8) {
+func NamedStringARB(xtype uint32, namelen int32, name *uint8, stringlen int32, xstring *uint8) {
 	C.glowNamedStringARB(gpNamedStringARB, (C.GLenum)(xtype), (C.GLint)(namelen), (*C.GLchar)(unsafe.Pointer(name)), (C.GLint)(stringlen), (*C.GLchar)(unsafe.Pointer(xstring)))
 }
 
@@ -22844,18 +22843,18 @@ func NormalStream3svATI(stream uint32, coords *int16) {
 }
 
 // label a named object identified within a namespace
-func ObjectLabel(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabel(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabel(gpObjectLabel, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *int8) {
+func ObjectLabelKHR(identifier uint32, name uint32, length int32, label *uint8) {
 	C.glowObjectLabelKHR(gpObjectLabelKHR, (C.GLenum)(identifier), (C.GLuint)(name), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 
 // label a a sync object identified by a pointer
-func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabel(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabel(gpObjectPtrLabel, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
-func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *int8) {
+func ObjectPtrLabelKHR(ptr unsafe.Pointer, length int32, label *uint8) {
 	C.glowObjectPtrLabelKHR(gpObjectPtrLabelKHR, ptr, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(label)))
 }
 func ObjectPurgeableAPPLE(objectType uint32, name uint32, option uint32) uint32 {
@@ -23757,13 +23756,13 @@ func PushClientAttribDefaultEXT(mask uint32) {
 }
 
 // push a named debug group into the command stream
-func PushDebugGroup(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroup(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroup(gpPushDebugGroup, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushDebugGroupKHR(source uint32, id uint32, length int32, message *int8) {
+func PushDebugGroupKHR(source uint32, id uint32, length int32, message *uint8) {
 	C.glowPushDebugGroupKHR(gpPushDebugGroupKHR, (C.GLenum)(source), (C.GLuint)(id), (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(message)))
 }
-func PushGroupMarkerEXT(length int32, marker *int8) {
+func PushGroupMarkerEXT(length int32, marker *uint8) {
 	C.glowPushGroupMarkerEXT(gpPushGroupMarkerEXT, (C.GLsizei)(length), (*C.GLchar)(unsafe.Pointer(marker)))
 }
 
@@ -24309,10 +24308,10 @@ func ShaderOp3EXT(op uint32, res uint32, arg1 uint32, arg2 uint32, arg3 uint32) 
 }
 
 // Replaces the source code in a shader object
-func ShaderSource(shader uint32, count int32, xstring **int8, length *int32) {
+func ShaderSource(shader uint32, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSource(gpShaderSource, (C.GLuint)(shader), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
-func ShaderSourceARB(shaderObj uintptr, count int32, xstring **int8, length *int32) {
+func ShaderSourceARB(shaderObj uintptr, count int32, xstring **uint8, length *int32) {
 	C.glowShaderSourceARB(gpShaderSourceARB, (C.GLhandleARB)(shaderObj), (C.GLsizei)(count), (**C.GLcharARB)(unsafe.Pointer(xstring)), (*C.GLint)(unsafe.Pointer(length)))
 }
 
@@ -25077,7 +25076,7 @@ func TransformFeedbackBufferRange(xfb uint32, index uint32, buffer uint32, offse
 func TransformFeedbackStreamAttribsNV(count int32, attribs *int32, nbuffers int32, bufstreams *int32, bufferMode uint32) {
 	C.glowTransformFeedbackStreamAttribsNV(gpTransformFeedbackStreamAttribsNV, (C.GLsizei)(count), (*C.GLint)(unsafe.Pointer(attribs)), (C.GLsizei)(nbuffers), (*C.GLint)(unsafe.Pointer(bufstreams)), (C.GLenum)(bufferMode))
 }
-func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **int8, bufferMode uint32) {
+func TransformFeedbackVaryingsEXT(program uint32, count int32, varyings **uint8, bufferMode uint32) {
 	C.glowTransformFeedbackVaryingsEXT(gpTransformFeedbackVaryingsEXT, (C.GLuint)(program), (C.GLsizei)(count), (**C.GLchar)(unsafe.Pointer(varyings)), (C.GLenum)(bufferMode))
 }
 func TransformFeedbackVaryingsNV(program uint32, count int32, locations *int32, bufferMode uint32) {

--- a/type.go
+++ b/type.go
@@ -75,7 +75,8 @@ func (t Type) GoType() string {
 	case "GLfixed":
 		return t.pointers() + "int32"
 	case "GLchar", "GLcharARB":
-		return t.pointers() + "int8"
+    // Chosen (vs. byte) for compatibility where GL uses GLubyte for strings (e.g., glGetString)
+		return t.pointers() + "uint8"
 	case "GLboolean":
 		return t.pointers() + "bool"
 	case "GLenum", "GLbitfield":


### PR DESCRIPTION
Per discussion in #47 use `uint8` for `GLchar` instead of `int8`. Prefer `uint8` over `byte` because some GL functions, such as `glGetString` use `GLubyte` rather than `GLchar`.

My only hesitation is that this change represents an API change that has the possibility of breaking client code. I expect the majority of use cases to be funneled through `gl.Str` which makes the change transparent but any direct string manipulation will be affected.
