### PR TITLE
Remove array support from gl.Ptr

### DIFF
--- a/conversions.tmpl
+++ b/conversions.tmpl
@@ -13,7 +13,8 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer or slice and returns its GL-compatible address.
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)

--- a/conversions.tmpl
+++ b/conversions.tmpl
@@ -13,7 +13,7 @@ import (
 	"unsafe"
 )
 
-// Ptr takes a pointer, slice, or array and returns its GL-compatible address.
+// Ptr takes a pointer or slice and returns its GL-compatible address.
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)
@@ -34,8 +34,6 @@ func Ptr(data interface{}) unsafe.Pointer {
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
-	case reflect.Array:
-		addr = unsafe.Pointer(v.UnsafeAddr())
 	default:
 		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
 	}


### PR DESCRIPTION
Resolves (partially) go-gl/gl#2. We also need to regenerate the bindings.