### PR TITLE
Fix issue where "go fmt" would fail on some paths.

### DIFF
--- a/package.go
+++ b/package.go
@@ -59,8 +59,8 @@ func (pkg *Package) GeneratePackage(dir string) error {
 	}
 
 	// gofmt the generated .go files.
-	if err := exec.Command("go", "fmt", dir).Run(); err != nil {
-		return err
+	if err := exec.Command("gofmt", "-w", dir).Run(); err != nil {
+		return fmt.Errorf("gofmt error: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
"go fmt dir" works correctly when dir is a relative path like "./out", but it fails when dir is a relative path without dot or two dots, e.g., "out". This happens because "go fmt out" is interpreted as a request to format package "out" rather than relative directory "out".

To fix the problem, use "gofmt" binary with "-w" flag, it should work for both "./out" and "out" ways of specifying a relative directory, since it takes an argument of path rather than Go package.

Fixes #60.