### PR TITLE
Panic on invalid input to gl.Ptr.

### DIFF
--- a/tmpl/conversions.tmpl
+++ b/tmpl/conversions.tmpl
@@ -30,13 +30,15 @@ func Ptr(data interface{}) unsafe.Pointer {
 			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 			reflect.Float32, reflect.Float64:
 			addr = unsafe.Pointer(e.UnsafeAddr())
+		default:
+			panic(fmt.Errorf("unsupported pointer to type %s; must be a slice or pointer to a singular scalar value or the first element of an array or slice", e.Kind()))
 		}
 	case reflect.Uintptr:
 		addr = unsafe.Pointer(v.Pointer())
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
 	default:
-		panic(fmt.Sprintf("Unsupported type %s; must be a pointer, slice, or array", v.Type()))
+		panic(fmt.Errorf("unsupported type %s; must be a slice or pointer to a singular scalar value or the first element of an array or slice", v.Type()))
 	}
 	return addr
 }


### PR DESCRIPTION
Currently, gl.Ptr will simply not set value of adds when provided with
a pointer to a type that is not supported. That means it returns null
pointer, which is likely going to cause issues for user of gl.Ptr.
Instead of silently ignoring this, panic with a helpful error message.

Also follow up to #55 and remove mention of arrays, they are not
supported.

Fix for go-gl/gl#32.