### PR TITLE
Add a simple usage example for gl.Ptr.

### DIFF
--- a/tmpl/conversions.tmpl
+++ b/tmpl/conversions.tmpl
@@ -15,6 +15,12 @@ import "C"
 
 // Ptr takes a slice or pointer (to a singular scalar value or the first
 // element of an array or slice) and returns its GL-compatible address.
+//
+// For example:
+//
+// 	var data []uint8
+// 	...
+// 	gl.TexImage2D(gl.TEXTURE_2D, ..., gl.UNSIGNED_BYTE, gl.Ptr(&data[0]))
 func Ptr(data interface{}) unsafe.Pointer {
 	if data == nil {
 		return unsafe.Pointer(nil)


### PR DESCRIPTION
Needed for go-gl/gl#48.