### PR TITLE
Represent GLsync as uintptr, not unsafe.Pointer

### DIFF
--- a/type.go
+++ b/type.go
@@ -106,7 +106,10 @@ func (t Type) GoType() string {
 		// an integer type.
 		return t.pointers() + "uintptr"
 	case "GLsync":
-		return t.pointers() + "unsafe.Pointer"
+		// GLsync is an opaque pointer type and may not contain actual
+		// pointers but arbitrary numbers. Use uintptr instead of
+		// unsafe.Pointer, as the latter requires valid pointers.
+		return t.pointers() + "uintptr"
 	case "GLDEBUGPROC", "GLDEBUGPROCARB", "GLDEBUGPROCKHR":
 		// Special case mapping to the type defined in debug.tmpl
 		return "DebugProc"


### PR DESCRIPTION
Go treats unsafe.Pointer as actual pointers, requiring them to be valid,
and allowing them to keep Go memory referenced.

GLsync, however, can be of arbitrary value, such as simple incrementing
IDs, or values that look like – but aren't – Go memory.

In order to avoid faulty garbage collection behaviour, these values must
not be stored in unsafe.Pointer. Instead we use uintptr, which is
guaranteed to be large enough to hold GLsync values.

Closes go-gl/gl#71
Updates #63