### PR TITLE
Use addext, remext flags as overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A few notes about the flags to `generate`:
 - `xml`: The XML directory.
 - `tmpl`: The template directory.
 - `out`: The output directory for generated files.
-- `addext`: A regular expression describing which extensions to include. `.*` by default, including everything.
+- `addext`: A regular expression describing which extensions to include _in addition_ to those supported by the selected profile. Empty by default, including nothing additional. Takes precedence over explicit removal.
+- `remext`: A regular expression describing which extensions to exclude. Empty by default, excluding nothing.
 - `restrict`: A JSON file that explicitly lists what enumerations / functions that Glow should generate (see example.json).
-- `remext`: A regular expression describing which extensions to exclude. Empty by default, excluding nothing. Takes precedence over explicitly added regular expressions.
 - `lenientInit`: Flag to disable strict function availability checks at `Init` time. By default if any non-extension function pointer cannot be loaded then initialization fails; when this flag is set initialization will succeed with missing functions. Note that on some platforms unavailable functions will load successfully even but fail upon invocation so check against the OpenGL context what is supported.

--- a/main.go
+++ b/main.go
@@ -63,8 +63,8 @@ func generate(name string, args []string) {
 		api         = flags.String("api", "", "API to generate (e.g., gl)")
 		ver         = flags.String("version", "", "API version to generate (e.g., 4.1)")
 		profile     = flags.String("profile", "", "API profile to generate (e.g., core)")
-		addext      = flags.String("addext", ".*", "Regular expression of extensions to include (e.g., .*)")
-		remext      = flags.String("remext", "$^", "Regular expression of extensions to exclude (e.g., .*)")
+		addext      = flags.String("addext", "", "Regular expression of extensions to include (e.g., .*)")
+		remext      = flags.String("remext", "", "Regular expression of extensions to exclude (e.g., .*)")
 		restrict    = flags.String("restrict", "", "JSON file of symbols to restrict symbol generation")
 		lenientInit = flags.Bool("lenientInit", false, "When true missing functions do not fail Init")
 	)
@@ -75,14 +75,20 @@ func generate(name string, args []string) {
 		log.Fatalln("error parsing version:", err)
 	}
 
-	addExtRegexp, err := regexp.Compile(*addext)
-	if err != nil {
-		log.Fatalln("error parsing extension inclusion regexp:", err)
+	var addExtRegexp *regexp.Regexp = nil
+	if *addext != "" {
+		addExtRegexp, err = regexp.Compile(*addext)
+		if err != nil {
+			log.Fatalln("error parsing extension inclusion regexp:", err)
+		}
 	}
 
-	remExtRegexp, err := regexp.Compile(*remext)
-	if err != nil {
-		log.Fatalln("error parsing extension exclusion regexp:", err)
+	var remExtRegexp *regexp.Regexp = nil
+	if *remext != "" {
+		remExtRegexp, err = regexp.Compile(*remext)
+		if err != nil {
+			log.Fatalln("error parsing extension exclusion regexp:", err)
+		}
 	}
 
 	packageSpec := &PackageSpec{

--- a/spec.go
+++ b/spec.go
@@ -436,10 +436,11 @@ func (feature SpecificationFeature) shouldInclude(pkgSpec *PackageSpec) bool {
 }
 
 func (extension SpecificationExtension) shouldInclude(pkgSpec *PackageSpec) bool {
-	if !pkgSpec.AddExtRegexp.MatchString(extension.Name) {
-		return false
+	// User extension overrides take precedence
+	if pkgSpec.AddExtRegexp != nil && pkgSpec.AddExtRegexp.MatchString(extension.Name) {
+		return true
 	}
-	if pkgSpec.RemExtRegexp.MatchString(extension.Name) {
+	if pkgSpec.RemExtRegexp != nil && pkgSpec.RemExtRegexp.MatchString(extension.Name) {
 		return false
 	}
 	extensionAPI := pkgSpec.API
@@ -447,10 +448,7 @@ func (extension SpecificationExtension) shouldInclude(pkgSpec *PackageSpec) bool
 	if pkgSpec.API == "gl" && pkgSpec.Profile == "core" {
 		extensionAPI = "glcore"
 	}
-	if !extension.APIRegexp.MatchString(extensionAPI) {
-		return false
-	}
-	return true
+	return extension.APIRegexp.MatchString(extensionAPI)
 }
 
 func (addRem *specAddRemSet) shouldInclude(pkgSpec *PackageSpec) bool {


### PR DESCRIPTION
Fixes #77.

Should be functionality-neutral for go-gl/gl but hopefully more useful for folks building custom packages.