### PR TITLE
Use golang.org/x/tools/go/packages instead of build

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,9 +15,10 @@ import (
 
 func generate(name string, args []string) {
 	flags := flag.NewFlagSet(name, flag.ExitOnError)
+	dir := importPathToDir("github.com/go-gl/glow")
 	var (
-		xmlDir      = flags.String("xml", importPathToDir("github.com/go-gl/glow/xml"), "XML directory")
-		tmplDir     = flags.String("tmpl", importPathToDir("github.com/go-gl/glow/tmpl"), "Template directory")
+		xmlDir      = flags.String("xml", filepath.Join(dir, "xml"), "XML directory")
+		tmplDir     = flags.String("tmpl", filepath.Join(dir, "tmpl"), "Template directory")
 		outDir      = flags.String("out", "gl", "Output directory")
 		api         = flags.String("api", "", "API to generate (e.g., gl)")
 		ver         = flags.String("version", "", "API version to generate (e.g., 4.1)")

--- a/package.go
+++ b/package.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"go/build"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"golang.org/x/tools/go/packages"
 )
 
 // A Package holds the typedef, function, and enum definitions for a Go package.
@@ -134,12 +135,12 @@ func (pkg *Package) Filter(enums, functions map[string]bool) {
 }
 
 // importPathToDir resolves the absolute path from importPath.
-// There doesn't need to be a valid Go package inside that import path,
-// but the directory must exist. It calls log.Fatalln if it fails.
+// There needs to be a valid Go package inside that import path.
+// It calls log.Fatalln if it fails.
 func importPathToDir(importPath string) string {
-	p, err := build.Import(importPath, "", build.FindOnly)
+	pkgs, err := packages.Load(nil, importPath)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	return p.Dir
+	return filepath.Dir(pkgs[0].GoFiles[0])
 }


### PR DESCRIPTION
This PR makes glow use golang.org/x/tools/go/packages instead of build so that glow works with Go modules.

This is a refactoring and does not affect the output result.

@dmitshur  PTAL