### PR TITLE
Replace exported C types with unsafe.Pointer

### DIFF
--- a/package.go
+++ b/package.go
@@ -43,13 +43,13 @@ func (f *PackageFunction) Comment() string {
 	for _, p := range f.Function.Parameters {
 		t := p.Type
 		if t.GoType() == "unsafe.Pointer" && t.Name != "void" && t.Name != "GLvoid" {
-			lines = append(lines, fmt.Sprintf("// Parameter %s has type %s.", p.Name, strings.TrimSpace(t.GoCType())))
+			lines = append(lines, fmt.Sprintf("// Parameter %s has type %s.", p.Name, t.GoCType()))
 		}
 	}
 
 	r := f.Function.Return
 	if r.GoType() == "unsafe.Pointer" && r.Name != "void" && r.Name != "GLvoid" {
-		lines = append(lines, fmt.Sprintf("// Return value has type %s.", strings.TrimSpace(r.GoCType())))
+		lines = append(lines, fmt.Sprintf("// Return value has type %s.", r.GoCType()))
 	}
 
 	return strings.Join(lines, "\n//\n")

--- a/package.go
+++ b/package.go
@@ -31,6 +31,30 @@ type PackageFunction struct {
 	Doc      string
 }
 
+// Comment returns the comment explaining the function.
+func (fn *PackageFunction) Comment() string {
+	lines := []string{}
+	if len(fn.Doc) > 0 {
+		lines = append(lines, "// " + fn.Doc)
+	}
+
+	// Adds explanations about C types that are unsafe.Pointer in Go world.
+	// See also https://github.com/go-gl/gl/issues/113.
+	for _, p := range fn.Function.Parameters {
+		t := p.Type
+		if t.GoType() == "unsafe.Pointer" && t.Name != "void" && t.Name != "GLvoid" {
+			lines = append(lines, fmt.Sprintf("// Param '%s' type: '%s'", p.Name, strings.TrimSpace(t.CType())))
+		}
+	}
+
+	r := fn.Function.Return
+	if r.GoType() == "unsafe.Pointer" && r.Name != "void" && r.Name != "GLvoid" {
+		lines = append(lines, fmt.Sprintf("// Return type: %s", strings.TrimSpace(r.CType())))
+	}
+
+	return strings.Join(lines, "\n//\n")
+}
+
 // UniqueName returns a globally unique Go-compatible name for this package.
 func (pkg *Package) UniqueName() string {
 	version := strings.Replace(pkg.Version.String(), ".", "", -1)

--- a/package.go
+++ b/package.go
@@ -32,24 +32,24 @@ type PackageFunction struct {
 }
 
 // Comment returns the comment explaining the function.
-func (fn *PackageFunction) Comment() string {
-	lines := []string{}
-	if len(fn.Doc) > 0 {
-		lines = append(lines, "// " + fn.Doc)
+func (f *PackageFunction) Comment() string {
+	var lines []string
+	if f.Doc != "" {
+		lines = append(lines, "// " + f.Doc)
 	}
 
 	// Adds explanations about C types that are unsafe.Pointer in Go world.
 	// See also https://github.com/go-gl/gl/issues/113.
-	for _, p := range fn.Function.Parameters {
+	for _, p := range f.Function.Parameters {
 		t := p.Type
 		if t.GoType() == "unsafe.Pointer" && t.Name != "void" && t.Name != "GLvoid" {
-			lines = append(lines, fmt.Sprintf("// Param '%s' type: '%s'", p.Name, strings.TrimSpace(t.CType())))
+			lines = append(lines, fmt.Sprintf("// Param %s has type %s", p.Name, strings.TrimSpace(t.CType())))
 		}
 	}
 
-	r := fn.Function.Return
+	r := f.Function.Return
 	if r.GoType() == "unsafe.Pointer" && r.Name != "void" && r.Name != "GLvoid" {
-		lines = append(lines, fmt.Sprintf("// Return type: %s", strings.TrimSpace(r.CType())))
+		lines = append(lines, fmt.Sprintf("// Return value has type %s", strings.TrimSpace(r.CType())))
 	}
 
 	return strings.Join(lines, "\n//\n")

--- a/package.go
+++ b/package.go
@@ -43,13 +43,13 @@ func (f *PackageFunction) Comment() string {
 	for _, p := range f.Function.Parameters {
 		t := p.Type
 		if t.GoType() == "unsafe.Pointer" && t.Name != "void" && t.Name != "GLvoid" {
-			lines = append(lines, fmt.Sprintf("// Param %s has type %s", p.Name, strings.TrimSpace(t.CType())))
+			lines = append(lines, fmt.Sprintf("// Parameter %s has type '%s'.", p.Name, strings.TrimSpace(t.CType())))
 		}
 	}
 
 	r := f.Function.Return
 	if r.GoType() == "unsafe.Pointer" && r.Name != "void" && r.Name != "GLvoid" {
-		lines = append(lines, fmt.Sprintf("// Return value has type %s", strings.TrimSpace(r.CType())))
+		lines = append(lines, fmt.Sprintf("// Return value has type '%s'.", strings.TrimSpace(r.CType())))
 	}
 
 	return strings.Join(lines, "\n//\n")

--- a/package.go
+++ b/package.go
@@ -41,18 +41,16 @@ func (f *PackageFunction) Comment() string {
 	// Adds explanations about C types that are unsafe.Pointer in Go world.
 	// See also https://github.com/go-gl/gl/issues/113.
 	for _, p := range f.Function.Parameters {
-		t := p.Type
-		if t.GoType() == "unsafe.Pointer" && t.Name != "void" && t.Name != "GLvoid" {
+		if t := p.Type; t.GoType() == "unsafe.Pointer" && t.Name != "void" && t.Name != "GLvoid" {
 			lines = append(lines, fmt.Sprintf("// Parameter %s has type %s.", p.Name, t.GoCType()))
 		}
 	}
 
-	r := f.Function.Return
-	if r.GoType() == "unsafe.Pointer" && r.Name != "void" && r.Name != "GLvoid" {
+	if r := f.Function.Return; r.GoType() == "unsafe.Pointer" && r.Name != "void" && r.Name != "GLvoid" {
 		lines = append(lines, fmt.Sprintf("// Return value has type %s.", r.GoCType()))
 	}
 
-	return strings.Join(lines, "\n//\n")
+	return strings.Join(lines, "\n")
 }
 
 // UniqueName returns a globally unique Go-compatible name for this package.

--- a/package.go
+++ b/package.go
@@ -43,13 +43,13 @@ func (f *PackageFunction) Comment() string {
 	for _, p := range f.Function.Parameters {
 		t := p.Type
 		if t.GoType() == "unsafe.Pointer" && t.Name != "void" && t.Name != "GLvoid" {
-			lines = append(lines, fmt.Sprintf("// Parameter %s has type '%s'.", p.Name, strings.TrimSpace(t.CType())))
+			lines = append(lines, fmt.Sprintf("// Parameter %s has type %s.", p.Name, strings.TrimSpace(t.GoCType())))
 		}
 	}
 
 	r := f.Function.Return
 	if r.GoType() == "unsafe.Pointer" && r.Name != "void" && r.Name != "GLvoid" {
-		lines = append(lines, fmt.Sprintf("// Return value has type '%s'.", strings.TrimSpace(r.CType())))
+		lines = append(lines, fmt.Sprintf("// Return value has type %s.", strings.TrimSpace(r.GoCType())))
 	}
 
 	return strings.Join(lines, "\n//\n")

--- a/tmpl/package.tmpl
+++ b/tmpl/package.tmpl
@@ -94,9 +94,7 @@ func boolToInt(b bool) int {
 
 {{define "bridgeCall"}}C.glow{{.GoName}}(gp{{.GoName}}{{if ge (len .Parameters) 1}}, {{end}}{{template "paramsGoCall" .Parameters}}){{end}}
 {{range .Functions}}
-//glow:keepspace
 {{.Comment}}
-//glow:rmspace
 func {{.GoName}}({{template "paramsGoDecl" .Parameters}}){{if not .Return.IsVoid}} {{.Return.GoType}}{{end}} {
   {{range .Parameters}}
   {{if .Type.IsDebugProc}}userDebugCallback = {{.GoName}}{{end}}

--- a/tmpl/package.tmpl
+++ b/tmpl/package.tmpl
@@ -94,7 +94,9 @@ func boolToInt(b bool) int {
 
 {{define "bridgeCall"}}C.glow{{.GoName}}(gp{{.GoName}}{{if ge (len .Parameters) 1}}, {{end}}{{template "paramsGoCall" .Parameters}}){{end}}
 {{range .Functions}}
-{{with .Doc}}// {{.}}{{end}}
+//glow:keepspace
+{{.Comment}}
+//glow:rmspace
 func {{.GoName}}({{template "paramsGoDecl" .Parameters}}){{if not .Return.IsVoid}} {{.Return.GoType}}{{end}} {
   {{range .Parameters}}
   {{if .Type.IsDebugProc}}userDebugCallback = {{.GoName}}{{end}}

--- a/type.go
+++ b/type.go
@@ -128,7 +128,7 @@ func (t Type) ConvertGoToC(name string) string {
 	case "GLDEBUGPROC", "GLDEBUGPROCARB", "GLDEBUGPROCKHR":
 		return fmt.Sprintf("(C.%s)(unsafe.Pointer(&%s))", t.Name, name)
 	}
-	if t.PointerLevel >= 1 {
+	if t.PointerLevel >= 1 && t.GoType() != "unsafe.Pointer"{
 		return fmt.Sprintf("(%s)(unsafe.Pointer(%s))", t.GoCType(), name)
 	}
 	return fmt.Sprintf("(%s)(%s)", t.GoCType(), name)

--- a/type.go
+++ b/type.go
@@ -128,7 +128,7 @@ func (t Type) ConvertGoToC(name string) string {
 	case "GLDEBUGPROC", "GLDEBUGPROCARB", "GLDEBUGPROCKHR":
 		return fmt.Sprintf("(C.%s)(unsafe.Pointer(&%s))", t.Name, name)
 	}
-	if t.PointerLevel >= 1 && t.GoType() != "unsafe.Pointer"{
+	if t.PointerLevel >= 1 && t.GoType() != "unsafe.Pointer" {
 		return fmt.Sprintf("(%s)(unsafe.Pointer(%s))", t.GoCType(), name)
 	}
 	return fmt.Sprintf("(%s)(%s)", t.GoCType(), name)

--- a/type.go
+++ b/type.go
@@ -113,7 +113,7 @@ func (t Type) GoType() string {
 		// Special case mapping to the type defined in debug.tmpl
 		return "DebugProc"
 	}
-	return t.GoCType()
+	return "unsafe.Pointer"
 }
 
 // ConvertGoToC returns an expression that converts a variable from the Go type to the C type.


### PR DESCRIPTION
This PR replaces exported C types with `unsafe.Pointer` so that `gl` will not expose C types. This PR also adds comments describing the original C types.

Fixes https://github.com/go-gl/gl/issues/113

Output Example:

```go
// Parameter context has type *C.struct__cl_context.
// Parameter event has type *C.struct__cl_event.
func CreateSyncFromCLeventARB(context unsafe.Pointer, event unsafe.Pointer, flags uint32) uintptr {
...
}
```