### PR TITLE
Use pkg-config

### DIFF
--- a/tmpl/package.tmpl
+++ b/tmpl/package.tmpl
@@ -25,8 +25,10 @@ package {{.Name}}
 {{define "paramsGoCall"}}{{range $i, $p := .}}{{if ne $i 0}}, {{end}}{{$p.Type.ConvertGoToC $p.GoName}}{{end}}{{end}}
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo linux freebsd LDFLAGS: -lGL
 // #cgo windows       LDFLAGS: -lopengl32
+//
+// #cgo !egl,linux !egl,freebsd pkg-config: gl
+// #cgo egl,linux egl,freebsd   pkg-config: egl
 //
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN

--- a/tmpl/procaddr.tmpl
+++ b/tmpl/procaddr.tmpl
@@ -24,11 +24,11 @@ package {{.Name}}
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
 
-#cgo linux freebsd CFLAGS: -DTAG_POSIX
-#cgo linux freebsd LDFLAGS: -lGL
+#cgo linux freebsd              CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd    pkg-config: gl
 
-#cgo egl CFLAGS: -DTAG_EGL
-#cgo egl LDFLAGS: -lEGL
+#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd  pkg-config: egl
 
 
 // Check the EGL tag first as it takes priority over the platform's default

--- a/tmpl/procaddr.tmpl
+++ b/tmpl/procaddr.tmpl
@@ -24,11 +24,11 @@ package {{.Name}}
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL
 
-#cgo linux freebsd              CFLAGS: -DTAG_POSIX
-#cgo !egl,linux !egl,freebsd    pkg-config: gl
+#cgo linux freebsd CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd pkg-config: gl
 
-#cgo egl,linux egl,freebsd  CFLAGS: -DTAG_EGL
-#cgo egl,linux egl,freebsd  pkg-config: egl
+#cgo egl,linux egl,freebsd CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd pkg-config: egl
 
 
 // Check the EGL tag first as it takes priority over the platform's default


### PR DESCRIPTION
Switches Linux and FreeBSD to use the pkg-config psuedo flag. This fixes buidling on FreeBSD which was previously using the incorrect include paths. I'll follow-up with the generated updates to the gl repo.

It uses the approach suggested in go-gl/gl#98 to make both GLX and EGL work. The former works fine with both cube examples and I was able to compile the latter with `go build -tags egl`. However, neither example worked targeting EGL. The 4.1 cube failed to compile the vertex shader (I'm assuming this is expected because of version incompatibilities). The 2.1 version at least runs but the cube doesn't spin.

I didn't do further debugging (or testing on Linux) since I was just trying to get FreeBSD building with the standard OpenGL/GLFW libraries. I'm also still wrapping my head around the EGL/OpenGLES/Mesa relationships and versioning constraints.