### PR TITLE
Allow for specification overloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ wgl
 # Vim
 *.swp
 *.swo
+
+# GoLand
+.idea/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Overloads
 See subdirectory `xml/overload` for examples. The motivation here is to provide Go functions with different parameter signatures of existing OpenGL functions.
 
 For example, `glVertexAttribPointer(..., void *)` cannot be used with `gl.VertexAttribPointer(..., unsafe.Pointer)` when using arbitrary offset values. The `checkptr` safeguard will abort the program when doing so.
-Overloads allow to create an additional `gl.VertexAttribPointerWithOffset(..., uintptr)`, which calls the original function with appropriate casts.   
+Overloads allow the creation of an additional `gl.VertexAttribPointerWithOffset(..., uintptr)`, which calls the original OpenGL function with appropriate casts.   
 
 
 Custom Packages

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Features:
 - Go functions that mirror the C specification using Go types.
 - Support for multiple OpenGL APIs (GL/GLES/EGL/WGL/GLX/EGL), versions, and profiles.
 - Support for extensions (including debug callbacks).
+- Support for overloads to provide Go functions with different parameter signatures.
 
 See the [open issues](https://github.com/go-gl/glow/issues) for caveats about the current state of the implementation.
 
@@ -14,6 +15,15 @@ Generated Packages
 ------------------
 
 Generated OpenGL binding packages are available in the [go-gl/gl](https://github.com/go-gl/gl) repository.
+
+Overloads
+---------
+
+See subdirectory `xml/overload` for examples. The motivation here is to provide Go functions with different parameter signatures of existing OpenGL functions.
+
+For example, `glVertexAttribPointer(..., void *)` cannot be used with `gl.VertexAttribPointer(..., unsafe.Pointer)` when using arbitrary offset values. The `checkptr` safeguard will abort the program when doing so.
+Overloads allow to create an additional `gl.VertexAttribPointerWithOffset(..., uintptr)`, which calls the original function with appropriate casts.   
+
 
 Custom Packages
 ---------------

--- a/functions.go
+++ b/functions.go
@@ -8,6 +8,16 @@ type Function struct {
 	GoName     string // Go name of the function with the API prefix stripped
 	Parameters []Parameter
 	Return     Type
+	Overloads  []Overload
+}
+
+// An Overload describes an alternative signature for the same function.
+type Overload struct {
+	Name         string // C name of the original function
+	GoName       string // Go name of the original function
+	OverloadName string // Go name of the overload
+	Parameters   []Parameter
+	Return       Type
 }
 
 // A Parameter to a Function.

--- a/functions.go
+++ b/functions.go
@@ -13,7 +13,6 @@ type Function struct {
 
 // An Overload describes an alternative signature for the same function.
 type Overload struct {
-	Name         string // C name of the original function
 	GoName       string // Go name of the original function
 	OverloadName string // Go name of the overload
 	Parameters   []Parameter

--- a/main.go
+++ b/main.go
@@ -134,7 +134,6 @@ func parseSpecifications(xmlDir string) []*Specification {
 		if err != nil {
 			log.Fatalln("error reading XML overload file: ", specFile.Name(), err)
 		}
-		fmt.Printf("overloads: %v\n", overloads)
 		spec, err := NewSpecification(*registry, overloads)
 		if err != nil {
 			log.Fatalln("error parsing specification:", specFile.Name(), err)

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func performRestriction(pkg *Package, jsonPath string) {
 
 func parseSpecifications(xmlDir string) []*Specification {
 	specDir := filepath.Join(xmlDir, "spec")
+	overloadDir := filepath.Join(xmlDir, "overload")
 	specFiles, err := ioutil.ReadDir(specDir)
 	if err != nil {
 		log.Fatalln("error reading spec file entries:", err)
@@ -124,7 +125,17 @@ func parseSpecifications(xmlDir string) []*Specification {
 		if !strings.HasSuffix(specFile.Name(), "xml") {
 			continue
 		}
-		spec, err := NewSpecification(filepath.Join(specDir, specFile.Name()))
+
+		registry, err := readSpecFile(filepath.Join(specDir, specFile.Name()))
+		if err != nil {
+			log.Fatalln("error reading XML spec file: ", specFile.Name(), err)
+		}
+		overloads, err := readOverloadFile(filepath.Join(overloadDir, specFile.Name()))
+		if err != nil {
+			log.Fatalln("error reading XML overload file: ", specFile.Name(), err)
+		}
+		fmt.Printf("overloads: %v\n", overloads)
+		spec, err := NewSpecification(*registry, overloads)
 		if err != nil {
 			log.Fatalln("error parsing specification:", specFile.Name(), err)
 		}

--- a/overload.go
+++ b/overload.go
@@ -19,8 +19,14 @@ type xmlOverload struct {
 type xmlParameterChange struct {
 	// Index is the zero-based index of the parameter list.
 	Index int `xml:"index,attr"`
-	// Type describes a change in the type of a parameter.
-	Type xmlTypeChange `xml:"type"`
+	// Name describes a change of the parameter name.
+	Name *xmlNameChange `xml:"name"`
+	// Type describes a change of the parameter type.
+	Type *xmlTypeChange `xml:"type"`
+}
+
+type xmlNameChange struct {
+	Value string `xml:"value,attr"`
 }
 
 type xmlTypeChange struct {

--- a/overload.go
+++ b/overload.go
@@ -6,7 +6,7 @@ import (
 )
 
 type xmlOverloads struct {
-	List []xmlOverload `xml:"overload"`
+	Overloads []xmlOverload `xml:"overload"`
 }
 
 type xmlOverload struct {

--- a/overload.go
+++ b/overload.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/xml"
+	"os"
+)
+
+type xmlOverloads struct {
+	List []xmlOverload `xml:"overload"`
+}
+
+type xmlOverload struct {
+	Name         string `xml:"name,attr"`
+	OverloadName string `xml:"overloadName,attr"`
+
+	ParameterChanges []xmlParameterChange `xml:"parameterChanges>change"`
+}
+
+type xmlParameterChange struct {
+	// Index is the zero-based index of the parameter list.
+	Index int `xml:"index,attr"`
+	// Type describes a change in the type of a parameter.
+	Type xmlTypeChange `xml:"type"`
+}
+
+type xmlTypeChange struct {
+	Name         string `xml:"name,attr"`
+	PointerLevel int    `xml:"pointerLevel,attr"`
+}
+
+func readOverloadFile(file string) (xmlOverloads, error) {
+	var overloads xmlOverloads
+
+	_, err := os.Stat(file)
+	if err != nil {
+		return overloads, nil
+	}
+
+	f, err := os.Open(file)
+	if err != nil {
+		return overloads, err
+	}
+	defer f.Close()
+
+	err = xml.NewDecoder(f).Decode(&overloads)
+	return overloads, err
+}

--- a/overload.go
+++ b/overload.go
@@ -30,8 +30,7 @@ type xmlNameChange struct {
 }
 
 type xmlTypeChange struct {
-	Name         string `xml:"name,attr"`
-	PointerLevel int    `xml:"pointerLevel,attr"`
+	Signature string `xml:"signature,attr"`
 }
 
 func readOverloadFile(file string) (xmlOverloads, error) {

--- a/spec.go
+++ b/spec.go
@@ -209,11 +209,15 @@ func overloadFunction(function *Function, info xmlOverload) error {
 		param := &overload.Parameters[change.Index]
 
 		if change.Type != nil {
+			_, ctype, err := parseSignature(xmlSignature(change.Type.Signature))
+			if err != nil {
+				return fmt.Errorf("failed to parse signature of overload for <%s>: %v", info.Name, err)
+			}
 			// store original type definition as a cast, as this most likely will be needed.
 			param.Type.Cast = param.Type.CDefinition
-			param.Type.PointerLevel = change.Type.PointerLevel
-			param.Type.Name = change.Type.Name
-			param.Type.CDefinition = change.Type.Name + " " + param.Type.pointers()
+			param.Type.PointerLevel = ctype.PointerLevel
+			param.Type.Name = ctype.Name
+			param.Type.CDefinition = ctype.CDefinition
 		}
 		if change.Name != nil {
 			param.Name = change.Name.Value

--- a/spec.go
+++ b/spec.go
@@ -181,7 +181,7 @@ func parseFunctions(commands []xmlCommand) (specFunctions, error) {
 }
 
 func parseOverloads(functions specFunctions, overloads xmlOverloads) (specFunctions, error) {
-	for _, overloadInfo := range overloads.List {
+	for _, overloadInfo := range overloads.Overloads {
 		found := false
 		for key, function := range functions {
 			if key.name == overloadInfo.Name {

--- a/spec.go
+++ b/spec.go
@@ -222,7 +222,6 @@ func overloadFunction(function *Function, info xmlOverload) error {
 			param.Type.CDefinition = change.Type.Name + " " + param.Type.pointers()
 		}
 		if change.Name != nil {
-			fmt.Printf("name change\n")
 			param.Name = change.Name.Value
 		}
 	}

--- a/spec.go
+++ b/spec.go
@@ -180,6 +180,50 @@ func parseFunctions(commands []xmlCommand) (specFunctions, error) {
 	return functions, nil
 }
 
+func parseOverloads(functions specFunctions, overloads xmlOverloads) (specFunctions, error) {
+	for _, overloadInfo := range overloads.List {
+		found := false
+		for key, function := range functions {
+			if key.name == overloadInfo.Name {
+				found = true
+				err := overloadFunction(function, overloadInfo)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("function <%s> not found to overload", overloadInfo.Name)
+		}
+	}
+	return functions, nil
+}
+
+func overloadFunction(function *Function, info xmlOverload) error {
+	overload := Overload{
+		Name:         function.Name,
+		GoName:       function.GoName,
+		OverloadName: info.OverloadName,
+		Parameters:   make([]Parameter, len(function.Parameters)),
+		Return:       function.Return,
+	}
+	copy(overload.Parameters, function.Parameters)
+	for _, change := range info.ParameterChanges {
+		if (change.Index < 0) || (change.Index >= len(function.Parameters)) {
+			return fmt.Errorf("overload for <%s> has invalid parameter index", info.Name)
+		}
+		param := &overload.Parameters[change.Index]
+
+		// store original type definition as a cast, as this most likely will be needed.
+		param.Type.Cast = param.Type.CDefinition
+		param.Type.PointerLevel = change.Type.PointerLevel
+		param.Type.Name = change.Type.Name
+		param.Type.CDefinition = change.Type.Name + " " + param.Type.pointers()
+	}
+	function.Overloads = append(function.Overloads, overload)
+	return nil
+}
+
 func parseSignature(signature xmlSignature) (name string, ctype Type, err error) {
 	readingName := false
 	readingType := false
@@ -459,14 +503,14 @@ func (addRem *specAddRemSet) shouldInclude(pkgSpec *PackageSpec) bool {
 	return true
 }
 
-// NewSpecification creates a new specification based on an XML file.
-func NewSpecification(file string) (*Specification, error) {
-	registry, err := readSpecFile(file)
+// NewSpecification creates a new specification based on an XML registry.
+func NewSpecification(registry xmlRegistry, overloads xmlOverloads) (*Specification, error) {
+	functions, err := parseFunctions(registry.Commands)
 	if err != nil {
 		return nil, err
 	}
 
-	functions, err := parseFunctions(registry.Commands)
+	functions, err = parseOverloads(functions, overloads)
 	if err != nil {
 		return nil, err
 	}

--- a/spec.go
+++ b/spec.go
@@ -196,7 +196,6 @@ func parseOverloads(functions specFunctions, overloads xmlOverloads) (specFuncti
 
 func overloadFunction(function *Function, info xmlOverload) error {
 	overload := Overload{
-		Name:         function.Name,
 		GoName:       function.GoName,
 		OverloadName: info.OverloadName,
 		Parameters:   make([]Parameter, len(function.Parameters)),

--- a/spec.go
+++ b/spec.go
@@ -182,18 +182,13 @@ func parseFunctions(commands []xmlCommand) (specFunctions, error) {
 
 func parseOverloads(functions specFunctions, overloads xmlOverloads) (specFunctions, error) {
 	for _, overloadInfo := range overloads.Overloads {
-		found := false
-		for key, function := range functions {
-			if key.name == overloadInfo.Name {
-				found = true
-				err := overloadFunction(function, overloadInfo)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-		if !found {
+		function := functions.getByName(overloadInfo.Name)
+		if function == nil {
 			return nil, fmt.Errorf("function <%s> not found to overload", overloadInfo.Name)
+		}
+		err := overloadFunction(function, overloadInfo)
+		if err != nil {
+			return nil, err
 		}
 	}
 	return functions, nil
@@ -449,6 +444,15 @@ func (functions specFunctions) get(name, api string) *Function {
 		return function
 	}
 	return functions[specRef{name, ""}]
+}
+
+func (functions specFunctions) getByName(name string) *Function {
+	for key, function := range functions {
+		if key.name == name {
+			return function
+		}
+	}
+	return nil
 }
 
 func (enums specEnums) get(name, api string) *Enum {

--- a/spec.go
+++ b/spec.go
@@ -214,11 +214,17 @@ func overloadFunction(function *Function, info xmlOverload) error {
 		}
 		param := &overload.Parameters[change.Index]
 
-		// store original type definition as a cast, as this most likely will be needed.
-		param.Type.Cast = param.Type.CDefinition
-		param.Type.PointerLevel = change.Type.PointerLevel
-		param.Type.Name = change.Type.Name
-		param.Type.CDefinition = change.Type.Name + " " + param.Type.pointers()
+		if change.Type != nil {
+			// store original type definition as a cast, as this most likely will be needed.
+			param.Type.Cast = param.Type.CDefinition
+			param.Type.PointerLevel = change.Type.PointerLevel
+			param.Type.Name = change.Type.Name
+			param.Type.CDefinition = change.Type.Name + " " + param.Type.pointers()
+		}
+		if change.Name != nil {
+			fmt.Printf("name change\n")
+			param.Name = change.Name.Value
+		}
 	}
 	function.Overloads = append(function.Overloads, overload)
 	return nil

--- a/spec_test.go
+++ b/spec_test.go
@@ -1,0 +1,71 @@
+package main
+
+import "testing"
+
+func TestParseSignature(t *testing.T) {
+	tt := []struct {
+		input        string
+		expectedName string
+		expectedType Type
+	}{
+		{
+			input:        "const void *<name>pointer</name>",
+			expectedName: "pointer",
+			expectedType: Type{
+				Name:         "void",
+				PointerLevel: 1,
+				CDefinition:  "const void *",
+			},
+		},
+		{
+			input:        "<ptype>GLsizei</ptype> <name>stride</name>",
+			expectedName: "stride",
+			expectedType: Type{
+				Name:         "GLsizei",
+				PointerLevel: 0,
+				CDefinition:  "GLsizei ",
+			},
+		},
+		{
+			input:        "const <ptype>GLuint</ptype> *<name>value</name>",
+			expectedName: "value",
+			expectedType: Type{
+				Name:         "GLuint",
+				PointerLevel: 1,
+				CDefinition:  "const GLuint *",
+			},
+		},
+		{
+			input:        "<ptype>GLuint</ptype> <name>baseAndCount</name>[2]",
+			expectedName: "baseAndCount",
+			expectedType: Type{
+				Name:         "GLuint",
+				PointerLevel: 1,
+				CDefinition:  "GLuint *",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			name, ctype, err := parseSignature(xmlSignature(tc.input))
+			failed := false
+			if err != nil {
+				t.Logf("parseSignature returned error: %v", err)
+				failed = true
+			}
+			if name != tc.expectedName {
+				t.Logf("name [%s] does not match expected [%s]", name, tc.expectedName)
+				failed = true
+			}
+			if ctype != tc.expectedType {
+				t.Logf("type [%v] does not match expected [%v]", ctype, tc.expectedType)
+				failed = true
+			}
+			if failed {
+				t.Fail()
+			}
+		})
+	}
+}

--- a/spec_test.go
+++ b/spec_test.go
@@ -44,6 +44,15 @@ func TestParseSignature(t *testing.T) {
 				CDefinition:  "GLuint *",
 			},
 		},
+		{
+			input:        "uintptr_t **",
+			expectedName: "",
+			expectedType: Type{
+				Name:         "uintptr_t",
+				PointerLevel: 2,
+				CDefinition:  "uintptr_t **",
+			},
+		},
 	}
 
 	for _, tc := range tt {

--- a/tmpl/package.tmpl
+++ b/tmpl/package.tmpl
@@ -19,7 +19,7 @@ package {{.Name}}
 //glow:rmspace
 
 {{define "paramsCDecl"}}{{range $i, $p := .}}{{if ne $i 0}}, {{end}}{{$p.Type.CType}} {{$p.CName}}{{end}}{{end}}
-{{define "paramsCCall"}}{{range $i, $p := .}}{{if ne $i 0}}, {{end}}{{if $p.Type.IsDebugProc}}glowCDebugCallback{{else}}{{$p.CName}}{{end}}{{end}}{{end}}
+{{define "paramsCCall"}}{{range $i, $p := .}}{{if ne $i 0}}, {{end}}{{if $p.Type.IsDebugProc}}glowCDebugCallback{{else}}{{if ge (len $p.Type.Cast) 1}}({{$p.Type.Cast}})({{end}}{{$p.CName}}{{if ge (len $p.Type.Cast) 1}}){{end}}{{end}}{{end}}{{end}}
 
 {{define "paramsGoDecl"}}{{range $i, $p := .}}{{if ne $i 0}}, {{end}}{{$p.GoName}} {{$p.Type.GoType}}{{end}}{{end}}
 {{define "paramsGoCall"}}{{range $i, $p := .}}{{if ne $i 0}}, {{end}}{{$p.Type.ConvertGoToC $p.GoName}}{{end}}{{end}}
@@ -66,6 +66,11 @@ package {{.Name}}
 // static {{.Return.CType}} glow{{.GoName}}(GP{{toUpper .GoName}} fnptr{{if ge (len .Parameters) 1}}, {{end}}{{template "paramsCDecl" .Parameters}}) {
 //   {{if not .Return.IsVoid}}return {{end}}(*fnptr)({{template "paramsCCall" .Parameters}});
 // }
+// {{range .Overloads}}
+// static {{.Return.CType}} glow{{.OverloadName}}(GP{{toUpper .GoName}} fnptr{{if ge (len .Parameters) 1}}, {{end}}{{template "paramsCDecl" .Parameters}}) {
+//   {{if not .Return.IsVoid}}return {{end}}(*fnptr)({{template "paramsCCall" .Parameters}});
+// }
+// {{end}}
 // {{end}}
 //
 import "C"
@@ -95,6 +100,7 @@ func boolToInt(b bool) int {
 }
 
 {{define "bridgeCall"}}C.glow{{.GoName}}(gp{{.GoName}}{{if ge (len .Parameters) 1}}, {{end}}{{template "paramsGoCall" .Parameters}}){{end}}
+{{define "overloadCall"}}C.glow{{.OverloadName}}(gp{{.GoName}}{{if ge (len .Parameters) 1}}, {{end}}{{template "paramsGoCall" .Parameters}}){{end}}
 {{range .Functions}}
 {{.Comment}}
 func {{.GoName}}({{template "paramsGoDecl" .Parameters}}){{if not .Return.IsVoid}} {{.Return.GoType}}{{end}} {
@@ -107,6 +113,19 @@ func {{.GoName}}({{template "paramsGoDecl" .Parameters}}){{if not .Return.IsVoid
   return {{.Return.ConvertCToGo "ret"}}
   {{end}}
 }
+{{range .Overloads}}
+
+func {{.OverloadName}}({{template "paramsGoDecl" .Parameters}}){{if not .Return.IsVoid}} {{.Return.GoType}}{{end}} {
+  {{range .Parameters}}
+  {{if .Type.IsDebugProc}}userDebugCallback = {{.GoName}}{{end}}
+  {{end}}
+  {{if .Return.IsVoid}}{{template "overloadCall" .}}
+  {{else}}
+  ret := {{template "overloadCall" .}}
+  return {{.Return.ConvertCToGo "ret"}}
+  {{end}}
+}
+{{end}}
 {{end}}
 
 //glow:keepspace

--- a/type.go
+++ b/type.go
@@ -10,6 +10,7 @@ type Type struct {
 	Name         string // Name of the type without modifiers
 	PointerLevel int    // Number of levels of declared indirection to the type
 	CDefinition  string // Raw C definition
+	Cast         string // Raw C cast in case conversion is necessary
 }
 
 // A Typedef describes a C typedef statement.
@@ -112,6 +113,8 @@ func (t Type) GoType() string {
 	case "GLDEBUGPROC", "GLDEBUGPROCARB", "GLDEBUGPROCKHR":
 		// Special case mapping to the type defined in debug.tmpl
 		return "DebugProc"
+	case "uintptr_t":
+		return t.pointers() + "uintptr"
 	}
 	return "unsafe.Pointer"
 }

--- a/type_test.go
+++ b/type_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestGoType(t *testing.T) {
+	tt := []struct {
+		in       Type
+		expected string
+	}{
+		{
+			in: Type{
+				Name:         "uintptr_t",
+				PointerLevel: 1,
+				CDefinition:  "uintptr_t*",
+				Cast:         "void *",
+			},
+			expected: "*uintptr",
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.in.String(), func(t *testing.T) {
+			goType := tc.in.GoType()
+			if goType != tc.expected {
+				t.Errorf("expected <%s>, got <%s>", tc.expected, goType)
+			}
+		})
+	}
+}

--- a/xml/overload/gl.xml
+++ b/xml/overload/gl.xml
@@ -1,0 +1,24 @@
+<overloads>
+    <overload name="glDrawElements" overloadName="DrawElementsWithOffset">
+        <parameterChanges>
+            <change index="3">
+                <type name="uintptr_t" pointerLevel="0" cast="void *" />
+            </change>
+        </parameterChanges>
+    </overload>
+
+    <overload name="glVertexAttribPointer" overloadName="VertexAttribOffset">
+        <parameterChanges>
+            <change index="5">
+                <type name="uintptr_t" pointerLevel="0" cast="void *" />
+            </change>
+        </parameterChanges>
+    </overload>
+    <overload name="glGetVertexAttribPointerv" overloadName="GetVertexAttribOffsetv">
+        <parameterChanges>
+            <change index="2">
+                <type name="uintptr_t" pointerLevel="2" cast="void **" />
+            </change>
+        </parameterChanges>
+    </overload>
+</overloads>

--- a/xml/overload/gl.xml
+++ b/xml/overload/gl.xml
@@ -2,7 +2,7 @@
     <overload name="glDrawElements" overloadName="DrawElementsWithOffset">
         <parameterChanges>
             <change index="3">
-                <type name="uintptr_t" pointerLevel="0" cast="void *" />
+                <type name="uintptr_t" pointerLevel="0" />
             </change>
         </parameterChanges>
     </overload>
@@ -11,7 +11,7 @@
         <parameterChanges>
             <change index="5">
                 <name value="offset" />
-                <type name="uintptr_t" pointerLevel="0" cast="void *" />
+                <type name="uintptr_t" pointerLevel="0" />
             </change>
         </parameterChanges>
     </overload>
@@ -19,7 +19,7 @@
         <parameterChanges>
             <change index="2">
                 <name value="offset" />
-                <type name="uintptr_t" pointerLevel="2" cast="void **" />
+                <type name="uintptr_t" pointerLevel="2" />
             </change>
         </parameterChanges>
     </overload>

--- a/xml/overload/gl.xml
+++ b/xml/overload/gl.xml
@@ -7,7 +7,7 @@
         </parameterChanges>
     </overload>
 
-    <overload name="glVertexAttribPointer" overloadName="VertexAttribOffset">
+    <overload name="glVertexAttribPointer" overloadName="VertexAttribPointerWithOffset">
         <parameterChanges>
             <change index="5">
                 <name value="offset" />
@@ -15,7 +15,7 @@
             </change>
         </parameterChanges>
     </overload>
-    <overload name="glGetVertexAttribPointerv" overloadName="GetVertexAttribOffsetv">
+    <overload name="glGetVertexAttribPointerv" overloadName="GetVertexAttribPointerWithOffsetv">
         <parameterChanges>
             <change index="2">
                 <name value="offset" />

--- a/xml/overload/gl.xml
+++ b/xml/overload/gl.xml
@@ -10,6 +10,7 @@
     <overload name="glVertexAttribPointer" overloadName="VertexAttribOffset">
         <parameterChanges>
             <change index="5">
+                <name value="offset" />
                 <type name="uintptr_t" pointerLevel="0" cast="void *" />
             </change>
         </parameterChanges>
@@ -17,6 +18,7 @@
     <overload name="glGetVertexAttribPointerv" overloadName="GetVertexAttribOffsetv">
         <parameterChanges>
             <change index="2">
+                <name value="offset" />
                 <type name="uintptr_t" pointerLevel="2" cast="void **" />
             </change>
         </parameterChanges>

--- a/xml/overload/gl.xml
+++ b/xml/overload/gl.xml
@@ -2,7 +2,7 @@
     <overload name="glDrawElements" overloadName="DrawElementsWithOffset">
         <parameterChanges>
             <change index="3">
-                <type name="uintptr_t" pointerLevel="0" />
+                <type signature="uintptr_t" />
             </change>
         </parameterChanges>
     </overload>
@@ -11,7 +11,7 @@
         <parameterChanges>
             <change index="5">
                 <name value="offset" />
-                <type name="uintptr_t" pointerLevel="0" />
+                <type signature="uintptr_t" />
             </change>
         </parameterChanges>
     </overload>
@@ -19,7 +19,7 @@
         <parameterChanges>
             <change index="2">
                 <name value="offset" />
-                <type name="uintptr_t" pointerLevel="2" />
+                <type signature="uintptr_t **" />
             </change>
         </parameterChanges>
     </overload>


### PR DESCRIPTION
This pull request is a proposal for the solution of current problems with `checkptr` and the `unsafe.Pointer` / `uintptr` converions. There are several issues across several projects already - I suppose go-gl/gl#80 is the most central one.

With this code change, it is possible to have (manually written) XML files under `<xmlDir>/overload` with same name as the main spec files. So, for `xml/spec/gl.xml` the file `xml/overload/gl.xml` would be matched.

I included a sample overload file, to showcase how this is to be used:
* For `gl.VertexAttribPointer(..., unsafe.Pointer)` it creates a `gl.VertexAttribOffset(..., uintptr)` overload
* For `gl.GetVertexAttribPointerv(..., *unsafe.Pointer)` it creates a `gl.GetVertexAttribOffsetv(..., **uintptr)` overload
* For `gl.DrawElements(..., unsafe.Pointer)` it creates a `gl.DrawElementsWithOffset(..., uintptr)` overload

The created code looks like this - example for `VertexAttribPointer`:
```
...
// static void  glowVertexAttribPointer(GPVERTEXATTRIBPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, const void * pointer) {
//   (*fnptr)(index, size, type, normalized, stride, pointer);
// }
// static void  glowVertexAttribOffset(GPVERTEXATTRIBPOINTER fnptr, GLuint  index, GLint  size, GLenum  type, GLboolean  normalized, GLsizei  stride, uintptr_t  offset) {
//   (*fnptr)(index, size, type, normalized, stride, (const void *)(offset));
// }
...
func VertexAttribPointer(index uint32, size int32, xtype uint32, normalized bool, stride int32, pointer unsafe.Pointer) {
	C.glowVertexAttribPointer(gpVertexAttribPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride), pointer)
}
func VertexAttribOffset(index uint32, size int32, xtype uint32, normalized bool, stride int32, offset uintptr) {
	C.glowVertexAttribOffset(gpVertexAttribPointer, (C.GLuint)(index), (C.GLint)(size), (C.GLenum)(xtype), (C.GLboolean)(boolToInt(normalized)), (C.GLsizei)(stride), (C.uintptr_t)(offset))
}
...
```

I wanted to stay clear of the core specification files, which is why a separate set of files is used.
I also don't know of all the affected cases. My guess (hope) would be, that, once accepted, people provide corresponding overloads via dedicated pull requests. Perhaps it's also a small subset of affected functions. Return types are not handled (are there cases?)

Also not clear is the naming. Should all the overloads have a suffix `WithOffset`? In the special case of `VertexAttribPointer` for instance, the WebGL variant even calls it `VertexAttribIPointer` (Note the extra `I` - also, their overload has one parameter less, something that could also be replicated...)

For all these uncertainties, I propose to continue the discussion in go-gl/gl#80 .