### PR TITLE
Fix static error when converting uintptr in gl.Ptr

### DIFF
--- a/tmpl/conversions.tmpl
+++ b/tmpl/conversions.tmpl
@@ -40,7 +40,7 @@ func Ptr(data interface{}) unsafe.Pointer {
 			panic(fmt.Errorf("unsupported pointer to type %s; must be a slice or pointer to a singular scalar value or the first element of an array or slice", e.Kind()))
 		}
 	case reflect.Uintptr:
-		addr = unsafe.Pointer(v.Pointer())
+		addr = unsafe.Pointer(data.(uintptr))
 	case reflect.Slice:
 		addr = unsafe.Pointer(v.Index(0).UnsafeAddr())
 	default:


### PR DESCRIPTION
https://github.com/go-gl/glow/blob/1d156fa734e09b832376abb0bc6fd33c8de4ffe4/tmpl/conversions.tmpl#L43

reflect will always panic on this conversion.  As uintptr is an integer type, it is not interpreted as a pointer in itself.  Also, this call is redundant per se as it returns a uintptr.  Just directly converting data to a uintptr and passing to unsafe.Pointer should get the expected result.