### PR TITLE
tmpl: add Windows support for the egl tag

### DIFF
--- a/tmpl/procaddr.tmpl
+++ b/tmpl/procaddr.tmpl
@@ -27,8 +27,9 @@ package {{.Name}}
 #cgo linux freebsd openbsd CFLAGS: -DTAG_POSIX
 #cgo !egl,linux !egl,freebsd !egl,openbsd pkg-config: gl
 
-#cgo egl,linux egl,freebsd egl,openbsd CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd egl,openbsd egl,windows CFLAGS: -DTAG_EGL
 #cgo egl,linux egl,freebsd egl,openbsd pkg-config: egl
+#cgo egl,windows LDFLAGS: -lEGL
 
 
 // Check the EGL tag first as it takes priority over the platform's default


### PR DESCRIPTION
Google's ANGLE library implements OpenGL ES on top of Windows GPU
APIs.

Updates #51