### PR TITLE
Add gles2 tag to support using ANGLE (EGL+ OpenGLES2) on windows

### DIFF
--- a/tmpl/package.tmpl
+++ b/tmpl/package.tmpl
@@ -25,7 +25,8 @@ package {{.Name}}
 {{define "paramsGoCall"}}{{range $i, $p := .}}{{if ne $i 0}}, {{end}}{{$p.Type.ConvertGoToC $p.GoName}}{{end}}{{end}}
 
 // #cgo darwin        LDFLAGS: -framework OpenGL
-// #cgo windows       LDFLAGS: -lopengl32
+// #cgo !gles2,windows       LDFLAGS: -lopengl32
+// #cgo gles2,windows        LDFLAGS: -lGLESv2
 //
 // #cgo !egl,linux !egl,freebsd !egl,openbsd pkg-config: gl
 // #cgo egl,linux egl,freebsd egl,openbsd    pkg-config: egl

--- a/tmpl/procaddr.tmpl
+++ b/tmpl/procaddr.tmpl
@@ -19,7 +19,8 @@ package {{.Name}}
 
 /*
 #cgo windows CFLAGS: -DTAG_WINDOWS
-#cgo windows LDFLAGS: -lopengl32
+#cgo !gles2,windows       LDFLAGS: -lopengl32
+#cgo gles2,windows        LDFLAGS: -lGLESv2
 
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo darwin LDFLAGS: -framework OpenGL


### PR DESCRIPTION
while still keep the Desktop OpenGL option default for windows.

With this change, the go-gl/gl binding can use EGL+OpenGL ES2 as an option by passing `egl` and `gles2` tags. (using[ ANGLE project](https://github.com/google/angle))

Without these tags, it can still use the default desktop OpenGL as before