### PR TITLE
Deprecate gl.PtrOffset

### DIFF
--- a/tmpl/conversions.tmpl
+++ b/tmpl/conversions.tmpl
@@ -50,8 +50,16 @@ func Ptr(data interface{}) unsafe.Pointer {
 }
 
 // PtrOffset takes a pointer offset and returns a GL-compatible pointer.
-// Useful for functions such as glVertexAttribPointer that take pointer
-// parameters indicating an offset rather than an absolute memory address.
+// Originally intended for functions such as glVertexAttribPointer that take pointer
+// parameters also for offsets, since Go 1.14 this is no longer recommended.
+//
+// Use a corresponding offset-compatible variant of the function instead.
+// For example, for gl.VertexAttribPointer() there is gl.VertexAttribPointerWithOffset().
+//
+// See https://github.com/go-gl/gl#go-114-and-checkptr for more details on the checkptr detector.
+// See https://github.com/go-gl/glow#overloads, about adding new overloads.
+//
+// Deprecated: Use more appropriate overload function instead
 func PtrOffset(offset int) unsafe.Pointer {
 	return unsafe.Pointer(uintptr(offset))
 }


### PR DESCRIPTION
With the overloads feature available, I believe it is good to also mark this information with `gl.PtrOffset()`, as it is one of the go-to points when `checkptr` fails.