### PR TITLE
drop use of slice header

### DIFF
--- a/tmpl/conversions.tmpl
+++ b/tmpl/conversions.tmpl
@@ -90,14 +90,13 @@ func Strs(strs ...string) (cstrs **uint8, free func()) {
 	for i := range strs {
 		n += len(strs[i])
 	}
+	if n == 0 {
+		n = 1 // avoid allocating zero bytes in case all strings are empty.
+	}
 	data := C.malloc(C.size_t(n))
 
 	// Copy all the strings into data.
-	dataSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(data),
-		Len:  n,
-		Cap:  n,
-	}))
+	dataSlice := (*[1 << 30]byte)(data)[:n]
 	css := make([]*uint8, len(strs)) // Populated with pointers to each string.
 	offset := 0
 	for i := range strs {


### PR DESCRIPTION
This PR changes how a raw array of bytes is cast back into a slice.
It is in preparation to handle go-gl/gl#132 .

The conversion is now done using a pointer to an arbitrarily large memory block, of which a slice is taken. The size is large enough to cover everything practical, and small enough to still be available on 32bit systems.

I also added another check, to avoid handling an empty slice because of empty strings - which would cause another error.