### PR TITLE
link to OpenGLES framework for ios compilation

### DIFF
--- a/tmpl/package.tmpl
+++ b/tmpl/package.tmpl
@@ -25,7 +25,7 @@ package {{.Name}}
 {{define "paramsGoCall"}}{{range $i, $p := .}}{{if ne $i 0}}, {{end}}{{$p.Type.ConvertGoToC $p.GoName}}{{end}}{{end}}
 
 // #cgo !gles2,darwin        LDFLAGS: -framework OpenGL
-// #cgo gles2,darwin         LDFLAGS: -lGLESv2
+// #cgo gles2,darwin         LDFLAGS: -framework OpenGLES
 // #cgo !gles2,windows       LDFLAGS: -lopengl32
 // #cgo gles2,windows        LDFLAGS: -lGLESv2
 //

--- a/tmpl/procaddr.tmpl
+++ b/tmpl/procaddr.tmpl
@@ -24,7 +24,7 @@ package {{.Name}}
 
 #cgo darwin CFLAGS: -DTAG_DARWIN
 #cgo !gles2,darwin LDFLAGS: -framework OpenGL
-#cgo gles2,darwin  LDFLAGS: -lGLESv2
+#cgo gles2,darwin  LDFLAGS: -framework OpenGLES
 
 #cgo linux freebsd openbsd CFLAGS: -DTAG_POSIX
 #cgo !egl,linux !egl,freebsd !egl,openbsd pkg-config: gl


### PR DESCRIPTION
Make the code compile for iOS targets. 
We can also add a new rule like `#cgo ios,darwin LDFLAGS: -framework OpenGLES` if the current rule has to be kept. You tell me.