### PR TITLE
netbsd support

### DIFF
--- a/tmpl/package.tmpl
+++ b/tmpl/package.tmpl
@@ -29,8 +29,8 @@ package {{.Name}}
 // #cgo !gles2,windows       LDFLAGS: -lopengl32
 // #cgo gles2,windows        LDFLAGS: -lGLESv2
 //
-// #cgo !egl,linux !egl,freebsd !egl,openbsd pkg-config: gl
-// #cgo egl,linux egl,freebsd egl,openbsd    pkg-config: egl
+// #cgo !egl,linux !egl,freebsd !egl,netbsd !egl,openbsd pkg-config: gl
+// #cgo egl,linux egl,freebsd !egl,netbsd egl,openbsd    pkg-config: egl
 //
 // #if defined(_WIN32) && !defined(APIENTRY) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__)
 // #ifndef WIN32_LEAN_AND_MEAN

--- a/tmpl/procaddr.tmpl
+++ b/tmpl/procaddr.tmpl
@@ -6,7 +6,7 @@
 //
 // windows: WGL
 // darwin: CGL
-// linux freebsd openbsd: GLX
+// linux freebsd netbsd openbsd: GLX
 //
 // Use of EGL instead of the platform's default (listed above) is made possible
 // via the "egl" build tag.
@@ -26,11 +26,11 @@ package {{.Name}}
 #cgo !gles2,darwin LDFLAGS: -framework OpenGL
 #cgo gles2,darwin  LDFLAGS: -framework OpenGLES
 
-#cgo linux freebsd openbsd CFLAGS: -DTAG_POSIX
-#cgo !egl,linux !egl,freebsd !egl,openbsd pkg-config: gl
+#cgo linux freebsd netbsd openbsd CFLAGS: -DTAG_POSIX
+#cgo !egl,linux !egl,freebsd !egl,netbsd !egl,openbsd pkg-config: gl
 
-#cgo egl,linux egl,freebsd egl,openbsd egl,windows CFLAGS: -DTAG_EGL
-#cgo egl,linux egl,freebsd egl,openbsd pkg-config: egl
+#cgo egl,linux egl,freebsd egl,netbsd egl,openbsd egl,windows CFLAGS: -DTAG_EGL
+#cgo egl,linux egl,freebsd egl,netbsd egl,openbsd pkg-config: egl
 #cgo egl,windows LDFLAGS: -lEGL
 #cgo egl,darwin  LDFLAGS: -lEGL
 


### PR DESCRIPTION
simply add netbsd to everywhere freebsd and openbsd are mentioned. this works to let go-gl/glfw build on a netbsd-9.2 vm