### PR TITLE
Use static keyword on GlowGetProcAddress instead of unique suffix

### DIFF
--- a/tmpl/procaddr.tmpl
+++ b/tmpl/procaddr.tmpl
@@ -41,7 +41,7 @@ package {{.Name}}
 
 	#include <stdlib.h>
 	#include <EGL/egl.h>
-	void* GlowGetProcAddress_{{.UniqueName}}(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return eglGetProcAddress(name);
 	}
 
@@ -51,7 +51,7 @@ package {{.Name}}
 	#include <windows.h>
 	#include <stdlib.h>
 	static HMODULE ogl32dll = NULL;
-	void* GlowGetProcAddress_{{.UniqueName}}(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		void* pf = wglGetProcAddress((LPCSTR) name);
 		if (pf) {
 			return pf;
@@ -66,7 +66,7 @@ package {{.Name}}
 
 	#include <stdlib.h>
 	#include <dlfcn.h>
-	void* GlowGetProcAddress_{{.UniqueName}}(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return dlsym(RTLD_DEFAULT, name);
 	}
 
@@ -74,7 +74,7 @@ package {{.Name}}
 
 	#include <stdlib.h>
 	#include <GL/glx.h>
-	void* GlowGetProcAddress_{{.UniqueName}}(const char* name) {
+	static void* GlowGetProcAddress(const char* name) {
 		return glXGetProcAddress((const GLubyte *) name);
 	}
 
@@ -87,5 +87,5 @@ import "unsafe"
 func getProcAddress(namea string) unsafe.Pointer {
 	cname := C.CString(namea)
 	defer C.free(unsafe.Pointer(cname))
-	return C.GlowGetProcAddress_{{.UniqueName}}(cname)
+	return C.GlowGetProcAddress(cname)
 }


### PR DESCRIPTION
Fixes #88
Updates [go-gl/gl#85](https://github.com/go-gl/gl/issues/85#issuecomment-329692174)

---

I checked out a branch of glow to add VertexAttribIPointerWithOffset, but realised it had just been fixed in issue 118 / pr 119 a month ago! So while I was there I picked up this chore.