### PR TITLE
Provide typed OpenGL objects rather than raw uint32s

### DIFF
--- a/package.go
+++ b/package.go
@@ -20,9 +20,10 @@ type Package struct {
 	Profile string
 	TmplDir string
 
-	Typedefs  []*Typedef
-	Enums     map[string]*Enum
-	Functions map[string]*PackageFunction
+	Typedefs    []*Typedef
+	Enums       map[string]*Enum
+	Functions   map[string]*PackageFunction
+	TypeClasses map[string]string
 }
 
 // A PackageFunction is a package-specific Function wrapper.

--- a/tmpl/package.tmpl
+++ b/tmpl/package.tmpl
@@ -83,6 +83,12 @@ import (
   "unsafe"
 )
 
+type (
+  {{range $k, $v := .TypeClasses}}
+  {{$k}} {{$v}}
+  {{end}}
+)
+
 const (
   {{range .Enums}}
   {{.GoName}} = {{.Value}}

--- a/type.go
+++ b/type.go
@@ -8,6 +8,7 @@ import (
 // A Type describes the C and Go type of a function parameter or return value.
 type Type struct {
 	Name         string // Name of the type without modifiers
+	TypeClass    string // Type class of the resource (e.g. "Program", "Texture", "VertexArray")
 	PointerLevel int    // Number of levels of declared indirection to the type
 	CDefinition  string // Raw C definition
 	Cast         string // Raw C cast in case conversion is necessary
@@ -48,6 +49,10 @@ func (t Type) GoCType() string {
 
 // GoType returns the Go definition of the type.
 func (t Type) GoType() string {
+	if t.TypeClass != "" {
+		return t.pointers() + t.TypeClass
+	}
+
 	switch t.Name {
 	case "GLbyte":
 		return t.pointers() + "int8"


### PR DESCRIPTION
The OpenGL XML spec provides type annotations that we can use to create proper Go types, which allows the compiler to catch mistakes such as swapped or incorrect parameters:
```go
gl.AttachShader(shader, program)
```


The following sed script can be used to automatically rewrite some `gl.Gen*()` declarations:
```bash
sed -z -i -E 's/(var \w+) uint32(\s+gl.Gen)(\w+)(s\(1, &\w+\))/\1 gl.\3\2\3\4/g' *.go
```
```diff
-	var texture uint32
+	var texture gl.Texture
 	gl.GenTextures(1, &texture)
```




<details>

<summary>Click here to see a preview of what users of go-gl would need to do to port their code:</summary>

```diff
diff --git a/gl21-cube/cube.go b/gl21-cube/cube.go
index 4416ee9..9b00855 100644
--- a/gl21-cube/cube.go
+++ b/gl21-cube/cube.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	texture   uint32
+	texture   gl.Texture
 	rotationX float32
 	rotationY float32
 )
@@ -61,7 +61,7 @@ func main() {
 	}
 }
 
-func newTexture(file string) uint32 {
+func newTexture(file string) gl.Texture {
 	imgFile, err := os.Open(file)
 	if err != nil {
 		log.Fatalf("texture %q not found on disk: %v\n", file, err)
@@ -77,8 +77,8 @@ func newTexture(file string) uint32 {
 	}
 	draw.Draw(rgba, rgba.Bounds(), img, image.Point{0, 0}, draw.Src)
 
-	var texture uint32
 	gl.Enable(gl.TEXTURE_2D)
+	var texture gl.Texture
 	gl.GenTextures(1, &texture)
 	gl.BindTexture(gl.TEXTURE_2D, texture)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
diff --git a/gl41core-cube/cube.go b/gl41core-cube/cube.go
index 0f32200..94e79fe 100644
--- a/gl41core-cube/cube.go
+++ b/gl41core-cube/cube.go
@@ -86,11 +86,11 @@ func main() {
 	}
 
 	// Configure the vertex data
-	var vao uint32
+	var vao gl.VertexArray
 	gl.GenVertexArrays(1, &vao)
 	gl.BindVertexArray(vao)
 
-	var vbo uint32
+	var vbo gl.Buffer
 	gl.GenBuffers(1, &vbo)
 	gl.BindBuffer(gl.ARRAY_BUFFER, vbo)
 	gl.BufferData(gl.ARRAY_BUFFER, len(cubeVertices)*4, gl.Ptr(cubeVertices), gl.STATIC_DRAW)
@@ -139,7 +139,7 @@ func main() {
 	}
 }
 
-func newProgram(vertexShaderSource, fragmentShaderSource string) (uint32, error) {
+func newProgram(vertexShaderSource, fragmentShaderSource string) (gl.Program, error) {
 	vertexShader, err := compileShader(vertexShaderSource, gl.VERTEX_SHADER)
 	if err != nil {
 		return 0, err
@@ -174,7 +174,7 @@ func newProgram(vertexShaderSource, fragmentShaderSource string) (uint32, error)
 	return program, nil
 }
 
-func compileShader(source string, shaderType uint32) (uint32, error) {
+func compileShader(source string, shaderType uint32) (gl.Shader, error) {
 	shader := gl.CreateShader(shaderType)
 
 	csources, free := gl.Strs(source)
@@ -197,7 +197,7 @@ func compileShader(source string, shaderType uint32) (uint32, error) {
 	return shader, nil
 }
 
-func newTexture(file string) (uint32, error) {
+func newTexture(file string) (gl.Texture, error) {
 	imgFile, err := os.Open(file)
 	if err != nil {
 		return 0, fmt.Errorf("texture %q not found on disk: %v", file, err)
@@ -213,7 +213,7 @@ func newTexture(file string) (uint32, error) {
 	}
 	draw.Draw(rgba, rgba.Bounds(), img, image.Point{0, 0}, draw.Src)
 
-	var texture uint32
+	var texture gl.Texture
 	gl.GenTextures(1, &texture)
 	gl.ActiveTexture(gl.TEXTURE0)
 	gl.BindTexture(gl.TEXTURE_2D, texture)
```

</details>


<details>

<summary>Click here to see a preview of the go-gl/gl diff (truncated for brevity):</summary>

```diff
diff --git a/v4.1-core/gl/package.go b/v4.1-core/gl/package.go
index 0b58b86..5bee367 100644
--- a/v4.1-core/gl/package.go
+++ b/v4.1-core/gl/package.go
@@ -5277,6 +5277,20 @@ import (
 	"unsafe"
 )
 
+type (
+	Buffer            uint32
+	Framebuffer       uint32
+	Program           uint32
+	ProgramPipeline   uint32
+	Query             uint32
+	Renderbuffer      uint32
+	Sampler           uint32
+	Shader            uint32
+	Texture           uint32
+	TransformFeedback uint32
+	VertexArray       uint32
+)
+
 const (
 	ACCUM_ADJACENT_PAIRS_NV                                    = 0x90AD
 	ACTIVE_ATOMIC_COUNTER_BUFFERS                              = 0x92D9
@@ -8707,15 +8721,15 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
-func ActiveProgramEXT(program uint32) {
+func ActiveProgramEXT(program Program) {
 	C.glowActiveProgramEXT(gpActiveProgramEXT, (C.GLuint)(program))
 }
 
 // set the active program object for a program pipeline object
-func ActiveShaderProgram(pipeline uint32, program uint32) {
+func ActiveShaderProgram(pipeline ProgramPipeline, program Program) {
 	C.glowActiveShaderProgram(gpActiveShaderProgram, (C.GLuint)(pipeline), (C.GLuint)(program))
 }
-func ActiveShaderProgramEXT(pipeline uint32, program uint32) {
+func ActiveShaderProgramEXT(pipeline ProgramPipeline, program Program) {
 	C.glowActiveShaderProgramEXT(gpActiveShaderProgramEXT, (C.GLuint)(pipeline), (C.GLuint)(program))
 }
 
@@ -8728,7 +8742,7 @@ func ApplyFramebufferAttachmentCMAAINTEL() {
 }
 
 // Attaches a shader object to a program object
-func AttachShader(program uint32, shader uint32) {
+func AttachShader(program Program, shader Shader) {
 	C.glowAttachShader(gpAttachShader, (C.GLuint)(program), (C.GLuint)(shader))
 }
 
@@ -8747,10 +8761,10 @@ func BeginPerfQueryINTEL(queryHandle uint32) {
 }
 
 // delimit the boundaries of a query object
-func BeginQuery(target uint32, id uint32) {
+func BeginQuery(target uint32, id Query) {
 	C.glowBeginQuery(gpBeginQuery, (C.GLenum)(target), (C.GLuint)(id))
 }
-func BeginQueryIndexed(target uint32, index uint32, id uint32) {
+func BeginQueryIndexed(target uint32, index uint32, id Query) {
 	C.glowBeginQueryIndexed(gpBeginQueryIndexed, (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(id))
 }
 
@@ -8760,121 +8774,121 @@ func BeginTransformFeedback(primitiveMode uint32) {
 }
 
 // Associates a generic vertex attribute index with a named attribute variable
-func BindAttribLocation(program uint32, index uint32, name *uint8) {
+func BindAttribLocation(program Program, index uint32, name *uint8) {
 	C.glowBindAttribLocation(gpBindAttribLocation, (C.GLuint)(program), (C.GLuint)(index), (*C.GLchar)(unsafe.Pointer(name)))
 }
 
 // bind a named buffer object
-func BindBuffer(target uint32, buffer uint32) {
+func BindBuffer(target uint32, buffer Buffer) {
 	C.glowBindBuffer(gpBindBuffer, (C.GLenum)(target), (C.GLuint)(buffer))
 }
 
 // bind a buffer object to an indexed buffer target
-func BindBufferBase(target uint32, index uint32, buffer uint32) {
+func BindBufferBase(target uint32, index uint32, buffer Buffer) {
 	C.glowBindBufferBase(gpBindBufferBase, (C.GLenum)(target), (C.GLuint)(index), (C.GLuint)(buffer))
 }
```

</details>


Since this is a breaking change, feedback would be appreciated.
