### PR TITLE
Place khrplatform.h side-by-side with generated Go files

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,9 @@ func generate(name string, args []string) {
 			if err := pkg.GeneratePackage(*outDir); err != nil {
 				log.Fatalln("error generating package:", err)
 			}
-			if err := copyIncludes(filepath.Join(*xmlDir, "include"), *outDir); err != nil {
+			// Place khrplatform.h side-by-side with the Go source files to prevent
+			// `go mod vendor` from stripping away directories without any Go code.
+			if err := copyIncludes(filepath.Join(*xmlDir, "include/KHR"), *outDir); err != nil {
 				log.Fatalln("error copying includes:", err)
 			}
 			break

--- a/type.go
+++ b/type.go
@@ -158,5 +158,11 @@ func (t Typedef) CTypedef() string {
 	if strings.Contains(t.CDefinition, "GLsync") {
 		return "typedef uintptr_t GLsync;"
 	}
+
+	// Place khrplatform.h side-by-side with the Go source files to prevent
+	// `go mod vendor` from stripping away directories without any Go code.
+	if strings.Contains(t.CDefinition, "#include") {
+		return strings.ReplaceAll(t.CDefinition, "KHR/", "")
+	}
 	return t.CDefinition
 }


### PR DESCRIPTION
go-gl/gl#159 clobbers go-gl/gl#141 and go-gl/gl#142 , so this is an attempt at a different fix from the `glow` side.

 @andydotxyz Can you check to see if vendoring works with this patch applied? [Instructions for using `glow` are available here](https://github.com/go-gl/gl#generating)