### PR TITLE
Add links to khronos.org in generated documentation

### DIFF
--- a/package.go
+++ b/package.go
@@ -51,6 +51,13 @@ func (f *PackageFunction) Comment() string {
 		lines = append(lines, fmt.Sprintf("// Return value has type %s.", r.GoCType()))
 	}
 
+	if len(lines) > 0 {
+		lines = append(lines, "//glow:keepspace")
+		lines = append(lines, "// ")
+		lines = append(lines, "//glow:rmspace")
+	}
+	lines = append(lines, fmt.Sprintf("// https://registry.khronos.org/OpenGL-Refpages/gl4/html/%s.xhtml", f.Name))
+
 	return strings.Join(lines, "\n")
 }
 


### PR DESCRIPTION
Makes it more convenient to look up documentation:

![1717825076](https://github.com/go-gl/glow/assets/103326468/182e2016-a50f-4cc2-8d44-0c413c368c13)
